### PR TITLE
fix(auth): give the authorization error page a way out

### DIFF
--- a/backend/src/routes/auth/oauth.ts
+++ b/backend/src/routes/auth/oauth.ts
@@ -222,7 +222,7 @@ export const oauthRoutes = new Elysia({ tags: ['authentication'] })
 
   // ── SMART callback (delegates to @proxy-smart/auth) ───────────────────
   .get('/smart-callback', async ({ query, redirect, set }) => {
-    const { result } = await handleCallback(
+    const { result, session } = await handleCallback(
       { state: query.state, code: query.code, error: query.error, error_description: query.error_description, session_state: query.session_state },
       { config: smartProxyConfig, store: smartStore, logger: smartLogger, autoResolvePatient, getRegisteredRedirectUris },
     )
@@ -231,7 +231,13 @@ export const oauthRoutes = new Elysia({ tags: ['authentication'] })
       case 'redirect':
         return redirect(result.url)
       case 'error':
-        return authErrorPage({ status: result.status, error: result.error, errorDescription: result.error_description })
+        return authErrorPage({
+          status: result.status,
+          error: result.error,
+          errorDescription: result.error_description,
+          signedInAs: session?.fhirUser,
+          logoutUrl: `${config.baseUrl}/auth/logout`,
+        })
       case 'response':
         set.status = result.status
         return result.body

--- a/backend/src/routes/auth/smart-templates.ts
+++ b/backend/src/routes/auth/smart-templates.ts
@@ -7,8 +7,16 @@
  */
 
 /** Friendly HTML page shown for auth flow errors (expired session, invalid state, etc.) */
-export function authErrorPage(opts: { status: number; error: string; errorDescription: string }): Response {
-  const { status, error, errorDescription } = opts
+export function authErrorPage(opts: {
+  status: number
+  error: string
+  errorDescription: string
+  /** Who the browser is signed in as, when the flow got far enough to know. */
+  signedInAs?: string
+  /** Where "use a different account" goes. Omit to hide the action. */
+  logoutUrl?: string
+}): Response {
+  const { status, error, errorDescription, signedInAs, logoutUrl } = opts
   const title = error === 'invalid_request' ? 'Session Expired' : 'Authorization Error'
   const html = `<!DOCTYPE html>
 <html lang="en" class="dark">
@@ -39,10 +47,11 @@ a:hover{opacity:.85}
 <h2>${Bun.escapeHTML(title)}</h2>
 <p>${Bun.escapeHTML(errorDescription)}</p>
 <div class="actions">
-<a href="javascript:history.back()">Go Back</a>
+${logoutUrl ? `<a href="${Bun.escapeHTML(logoutUrl)}">Sign out and use a different account</a>` : ''}
+<a class="${logoutUrl ? 'secondary' : ''}" href="javascript:history.back()">Go Back</a>
 <a class="secondary" href="/">Home</a>
 </div>
-<div class="code">${Bun.escapeHTML(error)}</div>
+<div class="code">${Bun.escapeHTML(error)}${signedInAs ? `<br/>signed in as ${Bun.escapeHTML(signedInAs)}` : ''}</div>
 </div>
 </body>
 </html>`

--- a/packages/auth/src/callback-handler.ts
+++ b/packages/auth/src/callback-handler.ts
@@ -218,7 +218,11 @@ export async function handleCallback(
         clientId: session.clientId,
         fhirUser: session.fhirUser ?? '(none)',
       })
+      // The session rides along so the error page can name the account that was
+      // refused and offer to sign out of it — without it the user is told the wrong
+      // account is signed in and given no way to change that.
       return {
+        session,
         result: {
           type: 'error',
           status: 403,


### PR DESCRIPTION
## The report

A user signing in to the DICOM viewer hit:

> **403 — Authorization Error**
> Selecting a patient requires a practitioner account.
> `[Go Back]` `[Home]`
> `access_denied`

and asked, reasonably: why is there no sign-out button, and why can I not see which account I am signed in with.

## Why it was a dead end

`authErrorPage` takes exactly three values — `status`, `error`, `errorDescription` — so it has no session and no logout URL, and cannot answer either question. Both of its actions return to the same signed-in session, so the one thing that resolves the situation, signing out and returning as the right account, was not reachable from the page.

The refusal itself is correct and stays: `callback-handler` fails closed for a non-practitioner reaching the patient picker, and the comment above it explains why. This changes only what the user is told and what they can do next.

## The change

- `authErrorPage` accepts an optional `signedInAs` and `logoutUrl`. With a logout URL it renders **"Sign out and use a different account"** as the primary action; the identity appears next to the error code.
- `callback-handler` returns its `session` on the practitioner refusal. `CallbackResult` already had an optional `session` field, so no type change.
- The `/smart-callback` caller passes `session?.fhirUser` and `${config.baseUrl}/auth/logout`.

Both parameters are optional and both default to the previous rendering, so every other error path is untouched until it opts in.

## Checks

`typecheck:backend`, `typecheck:packages`, `lint:backend` clean. 1502 backend tests and 70 + 85 package tests pass.

## Related, not fixed here

The `dicom-viewer` client is registered `patientFacing: true` but its UI offers Switch Patient to everyone, which is what triggers this refusal in the first place. That belongs in the viewer and is a separate change.