### PR TITLE
fix(infra): give the backend room to breathe, 512 MB OOM-killed it

### DIFF
--- a/config/eslint/package.json
+++ b/config/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/eslint-config",
-  "version": "0.3.19-beta.202608251205.98cdfaa95",
+  "version": "0.3.19-beta.202608251250.8de49bbcd",
   "private": true,
   "type": "module",
   "exports": {

--- a/deploy/infra/lib/backend-stack.ts
+++ b/deploy/infra/lib/backend-stack.ts
@@ -304,10 +304,10 @@ export class BackendStack extends cdk.Stack {
       {
         cluster: this.cluster,
         serviceName: 'proxy-smart-backend',
-        // Right-sized from 512/2048: 30d avg CPU 0.8%, peak mem ~11% (~220 MB).
-        // Node process — 512 MB is ample. Autoscaling covers bursts.
+        // 512 MB was OOM-killed in prod (exit 137): ~410 MB baseline RSS leaves no
+        // headroom. The ~220 MB behind the previous sizing was JS heap, not RSS.
         cpu: 256,
-        memoryLimitMiB: 512,
+        memoryLimitMiB: 1024,
         desiredCount: 1,
 
         // Place tasks in private subnets so the RDS security group's

--- a/frontend/smart-dicom-template/package.json
+++ b/frontend/smart-dicom-template/package.json
@@ -3,7 +3,7 @@
   "displayName": "SMART DICOM Algorithm Template",
   "description": "Starter kit for building SMART on FHIR imaging algorithm apps. Clone, implement your algorithm in src/algorithm.ts, and deploy as a SMART app.",
   "private": true,
-  "version": "0.3.19-beta.202608251205.98cdfaa95",
+  "version": "0.3.19-beta.202608251250.8de49bbcd",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5180",

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Admin UI",
   "description": "A web-based administration interface for managing healthcare applications and resources via Proxy Smart.",
   "private": true,
-  "version": "0.3.19-beta.202608251205.98cdfaa95",
+  "version": "0.3.19-beta.202608251250.8de49bbcd",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/app-store/package.json
+++ b/packages/app-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/app-store",
-  "version": "0.3.19-beta.202608251205.98cdfaa95",
+  "version": "0.3.19-beta.202608251250.8de49bbcd",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR app store — manifest discovery, visibility configuration, and registry CRUD. Framework-agnostic.",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/auth",
-  "version": "0.3.19-beta.202608251205.98cdfaa95",
+  "version": "0.3.19-beta.202608251250.8de49bbcd",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR STU 2.2.0 server-side authorization proxy — launch context, session management, token enrichment. Framework-agnostic, IdP-pluggable.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/cli",
-  "version": "0.3.19-beta.202608251205.98cdfaa95",
+  "version": "0.3.19-beta.202608251250.8de49bbcd",
   "private": false,
   "type": "module",
   "description": "Admin CLI for the proxy-smart SMART on FHIR authorization proxy. Authenticates via Keycloak OAuth (device flow or client_credentials) and drives the admin REST API.",

--- a/packages/elysia-mcp/package.json
+++ b/packages/elysia-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@max-health-inc/elysia-mcp",
-  "version": "0.3.19-beta.202608251205.98cdfaa95",
+  "version": "0.3.19-beta.202608251250.8de49bbcd",
   "private": false,
   "type": "module",
   "description": "Auto-generate MCP tools and resources from Elysia routes via introspection. TypeBox-to-Standard-Schema bridge, Streamable HTTP transport, session management.",

--- a/packages/patient-picker/package.json
+++ b/packages/patient-picker/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Patient Picker",
   "description": "Patient selection UI shown during SMART standalone launch when patient context is needed.",
   "private": true,
-  "version": "0.3.19-beta.202608251205.98cdfaa95",
+  "version": "0.3.19-beta.202608251250.8de49bbcd",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5176",

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/e2e",
-  "version": "0.3.19-beta.202608251205.98cdfaa95",
+  "version": "0.3.19-beta.202608251250.8de49bbcd",
   "private": true,
   "description": "End-to-end Playwright tests for Proxy Smart apps",
   "scripts": {


### PR DESCRIPTION
## What happened

The production backend task ran at **256 CPU / 512 MB**. It idles at ~410 MB RSS (≈80% of the limit), climbed to 99.8%, and the kernel killed it:

```
exit 137 — OutOfMemoryError: container killed due to memory usage
```

Two kills today (14:28 and 14:36 CEST), each replacing the task.

## Why it looked like an auth bug

The SMART launch-context store is an in-memory `Map` (documented "single-node only"). Every OOM restart discards all pending authorization sessions, so users mid-launch got:

- `CODE_TO_TOKEN_ERROR ... error="invalid_code"` — the same code replayed after its session vanished
- `invalid_target` — `getSessionAudience` returns null, so the rewritten `resource` is lost

Both read as OAuth misconfiguration. Neither was.

## The sizing that led here

The previous comment cited "30d avg CPU 0.8%, peak mem ~11% (~220 MB)". That ~220 MB was **JS heap** — the admin dashboard reports `62MB / 287MB` heap while the container sits at ~410 MB. RSS (runtime, native modules, buffers) is what cgroup OOM acts on.

## The change

`memoryLimitMiB: 512 → 1024`. Same workload lands near 40%, matching what the Keycloak stack already gets, and less than the PACS and HAPI stacks.

CPU stays at 256 deliberately — the constraint is memory, and one variable at a time.

## Follow-ups this surfaced (not in this PR)

- **Autoscaling scales on CPU only** (`maxCapacity: 4`), so it never reacted to memory pressure. It also cannot help while the launch-context store is per-task: scaling out would break launches exactly the way the OOM restarts did. Redis-backing that store is the real fix.
- Memory climbed 80% → 100% over ~2h. Extra headroom buys time; if it climbs again it is a leak, and 1024 MB only delays it.