### PR TITLE
fix(auth): let a Person fhirUser reach the token endpoint instead of refusing it

### DIFF
--- a/packages/auth/src/callback-handler.test.ts
+++ b/packages/auth/src/callback-handler.test.ts
@@ -177,6 +177,87 @@ describe('callback-handler: patient picker gate', () => {
   })
 })
 
+describe('callback-handler: Person fhirUser reaches the token endpoint', () => {
+  /*
+   * REGRESSION. SMART allows `fhirUser` to name a Person, and Max Health's IdP emits exactly
+   * that (one Person per human, linking out to their Patient and/or Practitioner). The picker
+   * gate could only place `Patient/*`, so every such user was refused with "Selecting a patient
+   * requires a practitioner account" — a patient told to be a clinician. The token endpoint
+   * resolves Person → Patient per client, so the launch has to be allowed to reach it.
+   */
+  test('Person: forwards to the client instead of refusing with 403', async () => {
+    const store = new MemoryStore()
+    store.set('session-key', makeSession({ needsPatientPicker: true, fhirUser: 'Person/1007' }))
+
+    const deps: CallbackHandlerDeps = {
+      config: BASE_CONFIG,
+      store,
+      autoResolvePatient: async () => null,
+    }
+
+    const { result } = await handleCallback({ state: 'session-key', code: 'auth-code-123' }, deps)
+
+    expect(result.type).toBe('redirect')
+    expect(result.type === 'redirect' && result.url).toContain('app.example.com/callback')
+    expect(result.type === 'redirect' && result.url).not.toContain('patient-picker')
+  })
+
+  test('Person: never gets picker access, since it resolves to its OWN patient downstream', async () => {
+    const store = new MemoryStore()
+    store.set('session-key', makeSession({ needsPatientPicker: true, fhirUser: 'Person/1007' }))
+
+    const deps: CallbackHandlerDeps = { config: BASE_CONFIG, store, autoResolvePatient: async () => null }
+    await handleCallback({ state: 'session-key', code: 'auth-code-123' }, deps)
+
+    // The directory stays practitioner-only; deferring must not hand out `pickerAllowed`.
+    expect(store.get('session-key')?.pickerAllowed).toBeUndefined()
+    expect(store.get('session-key')?.needsPatientPicker).toBe(false)
+  })
+
+  test('Person as an absolute reference is recognised too', async () => {
+    const store = new MemoryStore()
+    store.set('session-key', makeSession({
+      needsPatientPicker: true,
+      fhirUser: 'https://fhir.example.com/Person/1007',
+    }))
+
+    const deps: CallbackHandlerDeps = { config: BASE_CONFIG, store, autoResolvePatient: async () => null }
+    const { result } = await handleCallback({ state: 'session-key', code: 'auth-code-123' }, deps)
+
+    expect(result.type).toBe('redirect')
+    expect(result.type === 'redirect' && result.url).not.toContain('patient-picker')
+  })
+
+  test('RelatedPerson is NOT a Person: still refused, because the token endpoint cannot place it', async () => {
+    /*
+     * Deferral covers exactly what `resolveFhirUserForClient` can resolve. Letting a
+     * RelatedPerson through would issue a token carrying `launch/patient` and no patient,
+     * which SMART forbids — the EHR SHALL establish a patient in context.
+     */
+    const store = new MemoryStore()
+    store.set('session-key', makeSession({ needsPatientPicker: true, fhirUser: 'RelatedPerson/carer-9' }))
+
+    const deps: CallbackHandlerDeps = { config: BASE_CONFIG, store, autoResolvePatient: async () => null }
+    const { result } = await handleCallback({ state: 'session-key', code: 'auth-code-123' }, deps)
+
+    expect(result.type).toBe('error')
+    expect(result.type === 'error' && result.status).toBe(403)
+  })
+
+  test('a resolved patient still wins over deferral', async () => {
+    // Deferral is the fallback for an unplaceable identity, not a bypass of real context.
+    const store = new MemoryStore()
+    store.set('session-key', makeSession({ needsPatientPicker: true, fhirUser: 'Person/1007' }))
+
+    const deps: CallbackHandlerDeps = { config: BASE_CONFIG, store, autoResolvePatient: async () => '1008' }
+    const { result } = await handleCallback({ state: 'session-key', code: 'auth-code-123' }, deps)
+
+    expect(result.type).toBe('redirect')
+    expect(store.get('session-key')?.patient).toBe('1008')
+    expect(store.get('session-key')?.needsPatientPicker).toBe(false)
+  })
+})
+
 describe('handlePatientSelect: duplicate submission guard', () => {
   test('returns redirect idempotently when patient already selected', () => {
     const store = new MemoryStore()

--- a/packages/auth/src/callback-handler.ts
+++ b/packages/auth/src/callback-handler.ts
@@ -10,7 +10,7 @@
 
 import type { LaunchSession, SmartProxyConfig, SmartProxyLogger, SmartProxyResult } from './types'
 import type { ILaunchContextStore } from './stores/interface'
-import { extractPatientFromFhirUser } from './fhir-user'
+import { extractPatientFromFhirUser, getFhirUserResourceType } from './fhir-user'
 import { isRedirectUriRegistered, type GetRegisteredRedirectUris } from './redirect-uri'
 
 export interface CallbackParams {
@@ -202,8 +202,32 @@ export async function handleCallback(
     }
   }
 
+  /*
+   * A PERSON IS DEFERRED, NOT REFUSED. SMART permits `fhirUser` to name a Person — the spec's
+   * case for "the authorized representative for >1 patients" — which is an identity rather than
+   * a patient, so `extractPatientFromFhirUser` cannot place it and the practitioner gate below
+   * would refuse it. The token endpoint already resolves it per client
+   * (`resolveFhirUserForClient` + the app's `patientFacing` flag) and derives `patient` from the
+   * result, so let the launch reach it. Refusing here failed EVERY patient whose identity is a
+   * Person, in every patient-facing app, with a message about practitioner accounts.
+   */
+  const deferPersonResolution =
+    session.needsPatientPicker &&
+    !session.patient &&
+    !patientAutoResolved &&
+    getFhirUserResourceType(session.fhirUser ?? '') === 'Person'
+
+  if (deferPersonResolution) {
+    store.update(sessionKey, { needsPatientPicker: false })
+    logger?.info('SMART callback: Person fhirUser, deferring patient context to the token endpoint', {
+      sessionKey: sessionKey.slice(0, 8) + '...',
+      clientId: session.clientId,
+      fhirUser: session.fhirUser,
+    })
+  }
+
   // If still needs picker after auto-resolve attempt, redirect to picker UI
-  if (session.needsPatientPicker && !session.patient && !patientAutoResolved) {
+  if (session.needsPatientPicker && !session.patient && !patientAutoResolved && !deferPersonResolution) {
     /*
      * ONLY PRACTITIONERS CHOOSE A PATIENT. The picker is a searchable directory of everyone on the
      * server, so reaching it must require positive evidence of being a clinician — not merely the


### PR DESCRIPTION
## The bug

Every patient whose `fhirUser` is a `Person` was refused at the SMART callback:

```
403 access_denied — "Selecting a patient requires a practitioner account."
```

A patient told to be a clinician. Reproduced on two separate accounts against production.

## Why it happened

SMART permits `fhirUser` to name a **Person** — [the spec's case](https://hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) for "the authorized representative for >1 patients" — alongside Patient, Practitioner, PractitionerRole and RelatedPerson. Max Health's IdP emits exactly that: one Person per human, linking out to their Patient and/or Practitioner, so a single claim serves both a patient-facing and a clinician app.

The picker gate could only place `Patient/*`:

- `autoResolvePatient` → `extractPatientFromFhirUser` → `/Patient\/([^/]+)$/` → **null** for a Person
- the session fallback uses the same helper → **null**
- `isPractitioner('Person/1007')` → **false** → 403

**The resolution already existed one step later.** `/token` calls `resolveFhirUserForClient`, which fetches the Person, follows its link to the Patient for a `patientFacing` client, and then derives `patient` from the result. It was never reached, because the gate fails closed first. An ordering bug, not a missing capability.

## The change

Defer instead of refuse. A Person is an identity we *can* place — just not at the callback.

Deliberately scoped:

| `fhirUser` | behaviour |
|---|---|
| `Patient/*` | unchanged — placed immediately |
| `Person/*` | **deferred** to `/token`, which resolves it per client |
| `Practitioner/*` | unchanged — picker |
| `RelatedPerson/*` | **still refused** |
| absent | **still refused** |

`RelatedPerson` stays refused on purpose: `resolveFhirUserForClient` cannot place it, so letting it through would issue a token carrying `launch/patient` with no patient context, which the spec forbids ("the EHR SHALL establish a patient in context"). Deferral covers exactly what the token endpoint can resolve, and nothing more.

## Security

The patient directory is no more reachable than before. `pickerAllowed` is never granted by this path — asserted by a test — so the picker stays practitioner-only. A deferred Person resolves to **its own** linked Patient using the user's own access token; it cannot reach anyone else's.

## Tests

5 new cases in `callback-handler.test.ts`, and the 9 existing gate tests still pass unchanged:

- Person forwards to the client rather than 403ing
- Person never receives `pickerAllowed`
- Person as an absolute reference (`https://…/Person/1007`) is recognised
- RelatedPerson is still refused
- a genuinely resolved patient still wins over deferral

`bun test packages/auth` → 75 pass. Launch-flow backend tests → 59 pass. Lint and typecheck clean.

## Follow-up once this ships

Two production workarounds become unnecessary and should be reverted:

1. `max.nussbaumer@maxhealth.tech` and `aidomination2024@gmail.com` had their Keycloak `fhirUser` hand-set to `Patient/*`. Restore them to `Person/*` so clinician resolution works again.
2. The `fhirUser-import` IdP mapper was set to `syncMode: IMPORT` to stop it overwriting those overrides. Restore `FORCE`, which is what the platform's own mapper definition requires — without it, a new member's claim never lands, because their first login precedes provisioning.