### PR TITLE
fix(infra): alarm on backend memory, and hold the floor that survived production

### DIFF
--- a/deploy/infra/lib/backend-stack.ts
+++ b/deploy/infra/lib/backend-stack.ts
@@ -17,6 +17,12 @@ import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import type { Construct } from 'constructs';
 import { managedRuleGroups } from './waf-rules.js';
 
+// 512 MiB was OOM-killed (exit 137) — the container idles near 410 MiB RSS.
+// Exported so test/backend-sizing.test.ts can hold the floor.
+export const BACKEND_TASK_CPU = 256;
+export const BACKEND_TASK_MEMORY_MIB = 1024;
+export const BACKEND_MEMORY_ALARM_PERCENT = 80;
+
 export interface BackendStackProps extends cdk.StackProps {
   vpc: ec2.IVpc;
   /**
@@ -304,10 +310,8 @@ export class BackendStack extends cdk.Stack {
       {
         cluster: this.cluster,
         serviceName: 'proxy-smart-backend',
-        // 512 MB was OOM-killed in prod (exit 137): ~410 MB baseline RSS leaves no
-        // headroom. The ~220 MB behind the previous sizing was JS heap, not RSS.
-        cpu: 256,
-        memoryLimitMiB: 1024,
+        cpu: BACKEND_TASK_CPU,
+        memoryLimitMiB: BACKEND_TASK_MEMORY_MIB,
         desiredCount: 1,
 
         // Place tasks in private subnets so the RDS security group's
@@ -396,6 +400,15 @@ export class BackendStack extends cdk.Stack {
       threshold: 10,
       evaluationPeriods: 2,
       alarmDescription: 'High rate of 5xx errors from backend ALB',
+    });
+
+    // Scaling targets CPU, so memory climbs to an OOM kill with every other alarm green.
+    new cloudwatch.Alarm(this, 'MemoryUtilizationAlarm', {
+      metric: this.service.service.metricMemoryUtilization(),
+      threshold: BACKEND_MEMORY_ALARM_PERCENT,
+      evaluationPeriods: 3,
+      alarmDescription:
+        'Backend task memory above 80% — an OOM restart discards all in-flight SMART launch sessions',
     });
 
     // Tags

--- a/deploy/infra/test/backend-sizing.test.ts
+++ b/deploy/infra/test/backend-sizing.test.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Max Health Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Commercial
+
+// The downsize that OOM-killed production (512 MiB, exit 137) was a two-line diff
+// nothing in CI could object to. This objects.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  BACKEND_TASK_CPU,
+  BACKEND_TASK_MEMORY_MIB,
+  BACKEND_MEMORY_ALARM_PERCENT,
+} from '../lib/backend-stack';
+
+/** Floor, not current value: raising headroom stays free. */
+const MEMORY_FLOOR_MIB = 1024;
+
+describe('backend task sizing', () => {
+  test('memory stays at or above the floor that survived production', () => {
+    expect(BACKEND_TASK_MEMORY_MIB).toBeGreaterThanOrEqual(MEMORY_FLOOR_MIB);
+  });
+
+  test('the CPU/memory pair is a valid Fargate combination', () => {
+    // 256 CPU only permits 512/1024/2048 MiB; a mismatch fails at deploy, not here.
+    const validForCpu: Record<number, number[]> = {
+      256: [512, 1024, 2048],
+      512: [1024, 2048, 3072, 4096],
+      1024: [2048, 3072, 4096, 5120, 6144, 7168, 8192],
+    };
+    expect(validForCpu[BACKEND_TASK_CPU]).toContain(BACKEND_TASK_MEMORY_MIB);
+  });
+
+  test('the memory alarm leaves room to react before the kernel does', () => {
+    expect(BACKEND_MEMORY_ALARM_PERCENT).toBeGreaterThan(0);
+    expect(BACKEND_MEMORY_ALARM_PERCENT).toBeLessThanOrEqual(85);
+  });
+});


### PR DESCRIPTION
## Nothing was watching memory

The scaling policy targets **CPU**. The existing alarms cover latency, unhealthy hosts, and 5xx. So a task could climb from 80% to an OOM kill with every signal green — which is what happened twice in one afternoon while CI reported healthy deploys.

```
exit 137 — OutOfMemoryError: container killed due to memory usage
```

Measured before/after the sizing fix:

| memory limit | idle | peak |
|---|---|---|
| 512 MiB | ~80% | 99.8% → OOM |
| 1024 MiB | ~19-24% | flat |

## Why an OOM here is expensive

The launch-context store is per-task, so every restart discards **all in-flight SMART authorizations**. Users saw `CODE_TO_TOKEN_ERROR / invalid_code` ("Code not valid") and `invalid_target` at the token exchange, which reads as OAuth misconfiguration rather than capacity. Considerable time went into chasing it as an auth bug.

## Changes

- `MemoryUtilizationAlarm` at 80% sustained over 3 periods.
- Task sizing moved into named exports (`BACKEND_TASK_CPU`, `BACKEND_TASK_MEMORY_MIB`, `BACKEND_MEMORY_ALARM_PERCENT`) so it is greppable and assertable — the original downsize landed as a two-line diff no test could object to.
- `deploy/infra/test/backend-sizing.test.ts`: holds the 1024 MiB floor (a floor, so raising headroom stays free) and checks the CPU/memory pair is a legal Fargate combination.

This is the repo's first test under `deploy/infra`.

## What I tried first, and dropped

A synthesized-template assertion via `Template.fromStack`. It worked, but CDK's built-in CloudFormation validation makes one synth of this stack take **over three minutes**, and `policyValidationBeta1: []` does not disable it. The imported-construct stubs would also drift as `BackendStackProps` evolves. Exported constants carry the contract at 652ms instead; the alarm is the real production control.

## Not addressed here

Autoscaling is `maxCapacity: 4` against a per-task in-memory launch store that documents itself as "single-node only". Scaling out would break SMART launches the same way the OOM restarts did. Redis-backing that store is the fix, and it is the highest-leverage item left.