### PR TITLE
fix(auth): make "sign out and use a different account" actually sign out

### DIFF
--- a/backend/src/lib/kc-session-resolver.ts
+++ b/backend/src/lib/kc-session-resolver.ts
@@ -158,6 +158,9 @@ export async function autoResolvePatient(
 
     if (!userId) return null
 
+    // /auth/logout needs this: a failed launch has no id_token_hint to log out with.
+    session.userSub = userId
+
     // Look up the user's fhirUser attribute
     const user = await admin.users.findOne({ id: userId })
     const fhirUser = user?.attributes?.fhirUser?.[0]

--- a/backend/src/routes/auth/oauth.ts
+++ b/backend/src/routes/auth/oauth.ts
@@ -15,6 +15,7 @@ import { tokenContextStore } from '@/lib/token-context-store'
 import { hasClientAssertion, translateClientAssertion, ClientAssertionError } from './backend-services'
 import { kcUnavailablePage, authErrorPage } from './smart-templates'
 import { autoResolvePatient } from '@/lib/kc-session-resolver'
+import { getAdminClient } from '@/lib/kc-admin-factory'
 import { smartProxyConfig, smartStore, keycloakAdapter, smartLogger } from './smart-proxy-setup'
 import { resolveClientBrandColors } from '@/lib/org-branding'
 import { safeCssColor } from '@/lib/brand-color'
@@ -30,6 +31,7 @@ import {
   toAbsoluteFhirUser,
   canReturnPatient,
   parseScopes,
+  resolvePostLogoutUri,
   type LaunchCodePayload,
   type AuthorizeParams,
   type TokenPayload,
@@ -236,7 +238,9 @@ export const oauthRoutes = new Elysia({ tags: ['authentication'] })
           error: result.error,
           errorDescription: result.error_description,
           signedInAs: session?.fhirUser,
-          logoutUrl: `${config.baseUrl}/auth/logout`,
+          logoutUrl: query.state
+            ? `${config.baseUrl}/auth/logout?state=${encodeURIComponent(query.state)}`
+            : `${config.baseUrl}/auth/logout`,
         })
       case 'response':
         set.status = result.status
@@ -482,7 +486,30 @@ export const oauthRoutes = new Elysia({ tags: ['authentication'] })
   // browser to a Keycloak URL. This avoids exposing the Keycloak logout and
   // logout-confirm pages through the reverse proxy (Caddy).
   .get('/logout', async ({ query, redirect }) => {
-    const postLogoutUri = query.post_logout_redirect_uri || `${config.baseUrl}/`
+    const session = query.state ? smartStore.get(query.state) : undefined
+
+    // A failed launch has no id_token_hint, so the session would otherwise survive.
+    if (session?.userSub) {
+      try {
+        const admin = await getAdminClient()
+        await admin?.users.logout({ id: session.userSub })
+        logger.auth.info('Ended Keycloak session for a failed launch', { clientId: session.clientId })
+      } catch (error) {
+        logger.auth.error('Admin logout failed', { error })
+      }
+    }
+
+    const logoutClientId = query.client_id || session?.clientId
+    const registeredForLogout = !session?.clientRedirectUri && query.post_logout_redirect_uri && logoutClientId
+      ? await getRegisteredRedirectUris(logoutClientId).catch(() => [])
+      : []
+
+    const postLogoutUri = resolvePostLogoutUri({
+      baseUrl: config.baseUrl,
+      sessionRedirectUri: session?.clientRedirectUri,
+      requested: query.post_logout_redirect_uri,
+      registered: registeredForLogout,
+    })
 
     if (query.id_token_hint && typeof query.id_token_hint === 'string' &&
         query.id_token_hint.split('.').length === 3 && query.id_token_hint.length > 50) {

--- a/backend/src/schemas/auth/oauth.ts
+++ b/backend/src/schemas/auth/oauth.ts
@@ -119,7 +119,8 @@ export type LoginQueryType = Static<typeof LoginQuery>
 export const LogoutQuery = t.Object({
   post_logout_redirect_uri: t.Optional(t.String({ description: 'Post-logout redirect URI (defaults to base URL)' })),
   id_token_hint: t.Optional(t.String({ description: 'ID token hint for logout' })),
-  client_id: t.Optional(t.String({ description: 'OAuth client ID' }))
+  client_id: t.Optional(t.String({ description: 'OAuth client ID' })),
+  state: t.Optional(t.String({ description: 'Launch session key, used to end the session and return to the app' }))
 }, { title: 'LogoutQuery' })
 export type LogoutQueryType = Static<typeof LogoutQuery>
 

--- a/config/eslint/package.json
+++ b/config/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/eslint-config",
-  "version": "0.3.20-beta.202608251330.c8b796ce6",
+  "version": "0.3.20-beta.202608251354.1cfc4b69b",
   "private": true,
   "type": "module",
   "exports": {

--- a/frontend/smart-dicom-template/package.json
+++ b/frontend/smart-dicom-template/package.json
@@ -3,7 +3,7 @@
   "displayName": "SMART DICOM Algorithm Template",
   "description": "Starter kit for building SMART on FHIR imaging algorithm apps. Clone, implement your algorithm in src/algorithm.ts, and deploy as a SMART app.",
   "private": true,
-  "version": "0.3.20-beta.202608251330.c8b796ce6",
+  "version": "0.3.20-beta.202608251354.1cfc4b69b",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5180",

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Admin UI",
   "description": "A web-based administration interface for managing healthcare applications and resources via Proxy Smart.",
   "private": true,
-  "version": "0.3.20-beta.202608251330.c8b796ce6",
+  "version": "0.3.20-beta.202608251354.1cfc4b69b",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/app-store/package.json
+++ b/packages/app-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/app-store",
-  "version": "0.3.20-beta.202608251330.c8b796ce6",
+  "version": "0.3.20-beta.202608251354.1cfc4b69b",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR app store — manifest discovery, visibility configuration, and registry CRUD. Framework-agnostic.",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/auth",
-  "version": "0.3.20-beta.202608251330.c8b796ce6",
+  "version": "0.3.20-beta.202608251354.1cfc4b69b",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR STU 2.2.0 server-side authorization proxy — launch context, session management, token enrichment. Framework-agnostic, IdP-pluggable.",

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -59,7 +59,7 @@ export {
 export { signLaunchCode, verifyLaunchCode, type LaunchCodeServiceOptions } from './launch-code'
 
 // ─── Redirect URI Validation ──────────────────────────────────────────────────
-export { isRedirectUriRegistered, type GetRegisteredRedirectUris } from './redirect-uri'
+export { isRedirectUriRegistered, resolvePostLogoutUri, type GetRegisteredRedirectUris } from './redirect-uri'
 
 export {
   isCimdClientId,

--- a/packages/auth/src/redirect-uri-validation.test.ts
+++ b/packages/auth/src/redirect-uri-validation.test.ts
@@ -20,7 +20,7 @@
 import { describe, test, expect } from 'bun:test'
 import { handleAuthorize, type AuthorizeInterceptorDeps } from './authorize-interceptor'
 import { handleCallback, type CallbackParams, type CallbackHandlerDeps } from './callback-handler'
-import { isRedirectUriRegistered } from './redirect-uri'
+import { isRedirectUriRegistered, resolvePostLogoutUri } from './redirect-uri'
 import { MemoryStore } from './stores/memory'
 import type { AuthorizeParams, LaunchSession, SmartProxyConfig } from './types'
 import type { IdPAdapter } from './idp/interface'
@@ -257,5 +257,47 @@ describe('isRedirectUriRegistered — Keycloak-compatible matching (exact + trai
 
   test('empty allowlist rejects everything', () => {
     expect(isRedirectUriRegistered('https://app.example.com/cb', [])).toBe(false)
+  })
+})
+
+describe('resolvePostLogoutUri', () => {
+  const BASE = 'https://proxy.example.com'
+
+  test('an unregistered requested URI is refused, not honoured', () => {
+    // Otherwise /logout is an open redirect: ?post_logout_redirect_uri=https://evil.example
+    expect(
+      resolvePostLogoutUri({ baseUrl: BASE, requested: 'https://evil.example/', registered: ['https://app.example.com/*'] }),
+    ).toBe('https://proxy.example.com/')
+  })
+
+  test('a registered requested URI is honoured', () => {
+    expect(
+      resolvePostLogoutUri({ baseUrl: BASE, requested: 'https://app.example.com/cb', registered: ['https://app.example.com/*'] }),
+    ).toBe('https://app.example.com/cb')
+  })
+
+  test('a session URI wins, and only its origin is used', () => {
+    expect(
+      resolvePostLogoutUri({ baseUrl: BASE, sessionRedirectUri: 'https://app.example.com/callback?x=1' }),
+    ).toBe('https://app.example.com')
+  })
+
+  test('the session URI is not overridden by a hostile request param', () => {
+    expect(
+      resolvePostLogoutUri({
+        baseUrl: BASE,
+        sessionRedirectUri: 'https://app.example.com/callback',
+        requested: 'https://evil.example/',
+      }),
+    ).toBe('https://app.example.com')
+  })
+
+  test('nothing usable lands on the proxy, never undefined', () => {
+    expect(resolvePostLogoutUri({ baseUrl: BASE })).toBe('https://proxy.example.com/')
+    expect(resolvePostLogoutUri({ baseUrl: 'https://proxy.example.com/' })).toBe('https://proxy.example.com/')
+  })
+
+  test('a malformed session URI falls back rather than throwing', () => {
+    expect(resolvePostLogoutUri({ baseUrl: BASE, sessionRedirectUri: 'not-a-url' })).toBe('https://proxy.example.com/')
   })
 })

--- a/packages/auth/src/redirect-uri.ts
+++ b/packages/auth/src/redirect-uri.ts
@@ -44,6 +44,36 @@ export type GetRegisteredRedirectUris = (clientId: string) => Promise<string[]>
  * @returns true if `candidate` exactly equals one of `registered`, or matches a
  *   trailing-wildcard pattern in `registered`.
  */
+/**
+ * Where to send the browser after logout.
+ *
+ * A launch session's `clientRedirectUri` was already validated at authorize, so its origin is
+ * trusted. Anything the caller supplies is not: unregistered values fall back to `baseUrl` rather
+ * than being honoured, which is what stops /logout being an open redirect.
+ */
+export function resolvePostLogoutUri(opts: {
+  baseUrl: string
+  sessionRedirectUri?: string
+  requested?: string
+  registered?: readonly string[]
+}): string {
+  const fallback = `${opts.baseUrl.replace(/\/+$/, '')}/`
+
+  if (opts.sessionRedirectUri) {
+    try {
+      return new URL(opts.sessionRedirectUri).origin
+    } catch {
+      return fallback
+    }
+  }
+
+  if (opts.requested && isRedirectUriRegistered(opts.requested, opts.registered ?? [])) {
+    return opts.requested
+  }
+
+  return fallback
+}
+
 export function isRedirectUriRegistered(candidate: string, registered: readonly string[]): boolean {
   for (const pattern of registered) {
     // Exact string match (RFC 6749 §3.1.2.3).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/cli",
-  "version": "0.3.20-beta.202608251330.c8b796ce6",
+  "version": "0.3.20-beta.202608251354.1cfc4b69b",
   "private": false,
   "type": "module",
   "description": "Admin CLI for the proxy-smart SMART on FHIR authorization proxy. Authenticates via Keycloak OAuth (device flow or client_credentials) and drives the admin REST API.",

--- a/packages/elysia-mcp/package.json
+++ b/packages/elysia-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@max-health-inc/elysia-mcp",
-  "version": "0.3.20-beta.202608251330.c8b796ce6",
+  "version": "0.3.20-beta.202608251354.1cfc4b69b",
   "private": false,
   "type": "module",
   "description": "Auto-generate MCP tools and resources from Elysia routes via introspection. TypeBox-to-Standard-Schema bridge, Streamable HTTP transport, session management.",

--- a/packages/patient-picker/package.json
+++ b/packages/patient-picker/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Patient Picker",
   "description": "Patient selection UI shown during SMART standalone launch when patient context is needed.",
   "private": true,
-  "version": "0.3.20-beta.202608251330.c8b796ce6",
+  "version": "0.3.20-beta.202608251354.1cfc4b69b",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5176",

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/e2e",
-  "version": "0.3.20-beta.202608251330.c8b796ce6",
+  "version": "0.3.20-beta.202608251354.1cfc4b69b",
   "private": true,
   "description": "End-to-end Playwright tests for Proxy Smart apps",
   "scripts": {


### PR DESCRIPTION
## Reported

Clicking "Sign out and use a different account" on the auth error page landed on `https://api.proxy-smart.com/` instead of a login form.

Investigating that turned up three faults behind one link. The error page passed `${baseUrl}/auth/logout` with no parameters.

## 1. It never logged anyone out

`/logout` only contacts Keycloak inside `if (query.id_token_hint ...)`. A launch that fails **before** token issuance has no id_token — which is exactly when this link is shown. So the link cleared nothing.

That is why a wrong-account 403 looked permanent in production: signing in again reused the surviving SSO session and hit the same 403, with no way out. Considerable time was lost to it.

## 2. It stranded the user on the proxy

`post_logout_redirect_uri` defaulted to `${baseUrl}/`, so "use a different account" ended on the proxy root rather than back at the app.

## 3. Open redirect

```ts
const postLogoutUri = query.post_logout_redirect_uri || `${config.baseUrl}/`
...
return redirect(postLogoutUri)
```

Taken from the query and redirected to, unvalidated. `?post_logout_redirect_uri=https://evil.example` worked.

## The fix

**Ending the session.** `autoResolvePatient` already resolves the Keycloak user id from `session_state` and discarded it; it now keeps it on the session, so `/logout` ends that user's sessions via `users.logout({ id })`. This keeps the existing deliberate decision not to expose Keycloak's logout pages through the reverse proxy — no browser redirect to Keycloak.

**The redirect target.** Moved into `resolvePostLogoutUri`, alongside `isRedirectUriRegistered` which it reuses:

| input | result |
|---|---|
| session `clientRedirectUri` | its **origin** (already validated at authorize) |
| requested + registered | honoured |
| requested + unregistered | **refused**, falls back to proxy |
| session URI + hostile request param | session wins |
| malformed session URI | falls back, does not throw |
| nothing | proxy root |

**The error page** now passes `?state=…` so logout can find the session, end the right account, and return the user to the app they came from.

## Tests

6 new cases on `resolvePostLogoutUri` in `redirect-uri-validation.test.ts`, including that an unregistered target is refused and that a hostile param cannot override the session.

`bun test packages/auth` → 81 pass. Launch-flow, post-logout and kc-session-resolver backend suites → 69 pass. Typecheck and lint clean across backend and packages.

## Note

The admin-API logout ends **all** of that user's Keycloak sessions, not just the current browser's. For "use a different account" that is the intent; worth knowing it also signs them out of other tabs.