### PR TITLE
fix(keycloak): create fhir-resource-server when missing (prod invalid_target)

### DIFF
--- a/backend/src/lib/fhir-server-store.ts
+++ b/backend/src/lib/fhir-server-store.ts
@@ -271,6 +271,21 @@ export async function getAllServers(): Promise<FHIRServerInfo[]> {
   return fhirServerStore.getAllServers()
 }
 
+/**
+ * RFC 8707 resource-indicator URL for a FHIR server — the exact `aud`/`resource`
+ * a SMART app requests for it: `{baseUrl}/{name}/{identifier}/{fhirVersion}`.
+ * Single source of truth so the token audience, the auth routes, and Keycloak
+ * resource-client provisioning cannot drift from one another.
+ */
+export function fhirResourceUrlFor(server: { identifier: string; metadata: { fhirVersion: string } }): string {
+  return `${config.baseUrl}/${config.name}/${server.identifier}/${server.metadata.fhirVersion}`
+}
+
+/** Resource-indicator URLs for every registered FHIR server, in registry order. */
+export async function getFhirResourceUrls(): Promise<string[]> {
+  return (await getAllServers()).map(fhirResourceUrlFor)
+}
+
 // Add a new server to the store
 export async function addServer(serverUrl: string, name?: string, organizationIds?: string[]): Promise<FHIRServerInfo> {
   try {

--- a/backend/src/lib/kc-system-provisioning.ts
+++ b/backend/src/lib/kc-system-provisioning.ts
@@ -16,6 +16,7 @@ import { config } from '../config'
 import { logger } from './logger'
 import { RESOURCE_INDICATORS_SCOPE } from './smart-client-enrichment'
 import { ensureMappersOnScope } from './smart-scope-mappers'
+import { getFhirResourceUrls } from './fhir-server-store'
 
 /** Keycloak client attribute: let this client introspect tokens it isn't in the aud of. */
 const ALLOW_INTROSPECTION_WITHOUT_AUDIENCE = 'allow.token.introspection.without.audience.check'
@@ -157,6 +158,66 @@ export async function ensureResourceServerClients(admin: KcAdminClient): Promise
         error: error instanceof Error ? error.message : String(error),
       })
     }
+  }
+
+  await ensureFhirResourceServerClient(admin)
+}
+
+/**
+ * `fhir-resource-server` — the resource client for the proxy FHIR base. Its
+ * `resource_url` carries the runtime server id + FHIR version (see
+ * fhirResourceUrlFor), so unlike the MCP client it is NOT safe to derive-and-
+ * overwrite on every boot: an earlier version did exactly that with a wrong
+ * value and broke every FHIR token exchange with `invalid_target`.
+ *
+ * So this is strictly CREATE-IF-MISSING. Environments whose realm export /
+ * deploy script already set the value keep it untouched; an environment that
+ * never got it (production imports with IGNORE_EXISTING, and only the beta
+ * deploy runs the reconcile script) has the gap filled with the URL the proxy
+ * itself advertises for its first FHIR server. If no server resolves yet, it is
+ * skipped — a later boot with the registry warm creates it.
+ *
+ * The `resource-indicators` scope already maps `fhir-resource-server` as an
+ * audience; without this client that mapper points at nothing and the FHIR
+ * `aud` cannot bind.
+ */
+async function ensureFhirResourceServerClient(admin: KcAdminClient): Promise<void> {
+  const clientId = 'fhir-resource-server'
+  try {
+    const existing = await admin.clients.find({ clientId, max: 1 })
+    if (existing.length > 0) {
+      logger.keycloak.debug('fhir-resource-server present — leaving its resource_url as owned by the realm export')
+      return
+    }
+
+    const resourceUrl = (await getFhirResourceUrls())[0]
+    if (!resourceUrl) {
+      logger.keycloak.warn('fhir-resource-server missing and no FHIR server resolved yet — skipping (will retry next boot)')
+      return
+    }
+
+    await admin.clients.create({
+      clientId,
+      name: 'FHIR Resource Server (RFC 8707 resource indicator)',
+      description: 'Non-login resource client. Holds resource_url = the proxy FHIR base.',
+      enabled: true,
+      protocol: 'openid-connect',
+      clientAuthenticatorType: 'client-secret',
+      publicClient: false,
+      bearerOnly: false,
+      standardFlowEnabled: false,
+      implicitFlowEnabled: false,
+      directAccessGrantsEnabled: false,
+      serviceAccountsEnabled: false,
+      authorizationServicesEnabled: false,
+      fullScopeAllowed: false,
+      attributes: { [RESOURCE_URL_ATTR]: resourceUrl },
+    })
+    logger.keycloak.info('Created resource-server client', { clientId, resourceUrl })
+  } catch (error) {
+    logger.keycloak.warn('Failed to reconcile fhir-resource-server', {
+      error: error instanceof Error ? error.message : String(error),
+    })
   }
 }
 

--- a/backend/test/resource-server-clients.test.ts
+++ b/backend/test/resource-server-clients.test.ts
@@ -23,6 +23,7 @@ import { describe, it, expect } from 'bun:test'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { RESOURCE_SERVER_CLIENT_IDS, resourceServerUrlFor } from '@/lib/kc-system-provisioning'
+import { fhirResourceUrlFor } from '@/lib/fhir-server-store'
 
 const REPO = join(import.meta.dir, '..', '..')
 
@@ -58,8 +59,17 @@ describe('resource-server client reconciliation', () => {
   })
 
   it('leaves the FHIR resource client to the export, which still declares it', () => {
-    // Guards the other direction: excluding it from reconciliation must not be
-    // read as "it does not matter" — the export is now its only owner.
+    // Guards the other direction: excluding it from derive-and-overwrite must not
+    // be read as "it does not matter" — the export owns its value where present.
     expect(exported.get('fhir-resource-server')).toBeDefined()
+  })
+
+  it('fhirResourceUrlFor rebuilds exactly the FHIR resource the export declares', () => {
+    // The create-only reconcile fills the gap (e.g. production, which imports with
+    // IGNORE_EXISTING) using this exact format. Pinning it to the export value is
+    // the same cross-check that would have caught the invalid_target regression.
+    const exportedFhir = exported.get('fhir-resource-server')!
+    const [identifier, fhirVersion] = exportedFhir.split('/').slice(-2)
+    expect(fhirResourceUrlFor({ identifier, metadata: { fhirVersion } })).toBe(exportedFhir)
   })
 })


### PR DESCRIPTION
## What

The backend reconciles the `mcp-resource-server` RFC 8707 resource client at startup but deliberately skips `fhir-resource-server`, because its `resource_url` embeds the runtime server id + FHIR version (deriving it wrongly once regressed FHIR token exchange). On a realm imported with `IGNORE_EXISTING` that never ran the deploy-time reconcile, the client can therefore be absent, and the `resource-indicators` scope's audience mapper then references a client that doesn't exist.

This adds a strictly **create-if-missing** reconcile for `fhir-resource-server`:

- **Exists** → left untouched (the realm export / deploy remains its owner; `RESOURCE_SERVER_CLIENT_IDS` stays `['mcp-resource-server']`).
- **Missing** → created with the URL the proxy advertises for its first FHIR server via a shared `fhirResourceUrlFor` helper (`{baseUrl}/{name}/{identifier}/{fhirVersion}`), so audience/auth/provisioning cannot drift.
- **No FHIR server resolved yet** → skipped (non-fatal); a later boot creates it.

Never overwrites an existing value, so it cannot reproduce the earlier derive-and-overwrite regression.

## Files
- `lib/fhir-server-store.ts`: `fhirResourceUrlFor` + `getFhirResourceUrls`
- `lib/kc-system-provisioning.ts`: `ensureFhirResourceServerClient` (create-only)
- `test/resource-server-clients.test.ts`: pin `fhirResourceUrlFor` to the realm-export value