### PR TITLE
feat(admin): reconcile RFC 8707 resource indicators via admin API (MCP-callable)

### DIFF
--- a/backend/src/lib/kc-system-provisioning.ts
+++ b/backend/src/lib/kc-system-provisioning.ts
@@ -327,6 +327,28 @@ async function attachResourceIndicatorsToExistingClients(
 }
 
 /**
+ * Reconcile the full RFC 8707 resource-indicator wiring on demand — the resource
+ * clients (including the create-only fhir-resource-server), the
+ * resource-indicators scope, and its audience mappers. This is the same work
+ * `ensureSystemClients` runs at boot, exposed so an operator can repair a drifted
+ * or partially-imported realm without a redeploy (e.g. via the admin API / MCP).
+ * Returns the resulting resource clients for confirmation. Idempotent; each step
+ * is individually non-fatal.
+ */
+export async function reconcileResourceIndicators(
+  admin: KcAdminClient,
+): Promise<{ clientId: string; resourceUrl?: string }[]> {
+  await ensureResourceServerClients(admin)
+  await ensureResourceIndicatorsScope(admin)
+  const summary: { clientId: string; resourceUrl?: string }[] = []
+  for (const clientId of RESOURCE_AUDIENCE_CLIENT_IDS) {
+    const found = await admin.clients.find({ clientId, max: 1 })
+    summary.push({ clientId, resourceUrl: found[0]?.attributes?.[RESOURCE_URL_ATTR] })
+  }
+  return summary
+}
+
+/**
  * Ensure the proxy's introspection client (admin-service) may introspect tokens
  * whose `aud` does not list it.
  *

--- a/backend/src/routes/admin/smart-config.ts
+++ b/backend/src/routes/admin/smart-config.ts
@@ -1,13 +1,15 @@
 // SPDX-FileCopyrightText: Max Health Inc.
 // SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Commercial
 
-import { Elysia } from 'elysia'
+import { Elysia, t } from 'elysia'
 import { smartConfigService } from '@/lib/smart-config'
 import { brandBundleService } from '@/lib/brand-bundle'
 import { validateToken } from '@/lib/auth'
 import { extractBearerToken } from '@/lib/admin-utils'
 import { handleAdminError } from '@/lib/admin-error-handler'
 import { CommonErrorResponses, SmartConfigRefreshResponse, type SmartConfigurationResponseType } from '@/schemas'
+import { getAdminClient } from '@/lib/kc-admin-factory'
+import { reconcileResourceIndicators } from '@/lib/kc-system-provisioning'
 
 /**
  * SMART Configuration Admin endpoints
@@ -48,4 +50,48 @@ export const smartConfigAdminRoutes = new Elysia({ prefix: '/smart-config', tags
       tags: ['admin', 'smart-apps'],
       security: [{ BearerAuth: [] }]
     }
+  })
+  .post('/reconcile-resource-indicators', async ({ set, headers }) => {
+    const auth = extractBearerToken(headers)
+    if (!auth) {
+      set.status = 401
+      return { error: 'Authentication required' }
+    }
+
+    try {
+      await validateToken(auth)
+
+      const admin = await getAdminClient()
+      if (!admin) {
+        set.status = 503
+        return { error: 'Keycloak admin client unavailable' }
+      }
+
+      const resourceClients = await reconcileResourceIndicators(admin)
+      return {
+        message: 'RFC 8707 resource-indicator wiring reconciled',
+        timestamp: new Date().toISOString(),
+        resourceClients,
+      }
+    } catch (error) {
+      return handleAdminError(error, set)
+    }
+  }, {
+    response: {
+      200: t.Object({
+        message: t.String(),
+        timestamp: t.String(),
+        resourceClients: t.Array(t.Object({
+          clientId: t.String(),
+          resourceUrl: t.Optional(t.String()),
+        })),
+      }),
+      ...CommonErrorResponses,
+    },
+    detail: {
+      summary: 'Reconcile RFC 8707 resource indicators',
+      description: 'Create/repair the resource-server clients (fhir-resource-server, mcp-resource-server), the resource-indicators client scope and its audience mappers, so SMART token exchange can bind the FHIR/MCP resource aud. Fixes invalid_target on a realm that was imported with IGNORE_EXISTING. Idempotent.',
+      tags: ['admin', 'smart-apps'],
+      security: [{ BearerAuth: [] }],
+    },
   })


### PR DESCRIPTION
## What

Adds `POST /admin/smart-config/reconcile-resource-indicators` — runs the RFC 8707 resource-indicator reconciliation on demand (the same work done at boot) as the backend's Keycloak admin service account:

- `ensureResourceServerClients` (incl. create-only `fhir-resource-server`), `ensureResourceIndicatorsScope` + audience mappers.
- Idempotent; each step non-fatal.
- Returns the resulting resource clients + their `resource_url` for confirmation.

Because the MCP tool surface is generated from admin routes, this also exposes an MCP tool (`create_admin_smart-config_reconcile-resource-indicators`), so the wiring can be provisioned/repaired without a deploy.

## Files
- `lib/kc-system-provisioning.ts`: `reconcileResourceIndicators(admin)` orchestrator
- `routes/admin/smart-config.ts`: authenticated POST endpoint (typed response + OpenAPI detail → MCP tool)

## Notes
- Purely additive; no behaviour change at boot. Does nothing until called, and only creates/repairs what's missing.
- Follow-up to #1050. Base is `develop`; promote via the normal develop → test → main flow.