### PR TITLE
fix: stop the beta deploy stripping prompt from the maxhealth broker

### DIFF
--- a/.github/scripts/deploy-beta-remote.sh
+++ b/.github/scripts/deploy-beta-remote.sh
@@ -293,6 +293,12 @@ fi
 # maxhealth IdP onto the beta host, then asserts no IdP references a foreign
 # environment — reconcile first so a normal deploy self-heals and only genuinely
 # unexpected drift fails the deploy.
+#
+# The payload below is a SECOND definition of an IdP whose source of truth is
+# scripts/register-maxhealth-idp.ts in the maxhealth.tech repo (see its
+# IDP_REGISTRATION.md). This PUT overwrites the whole representation, so a key
+# added there and not here is silently stripped on the next beta deploy — which
+# is exactly how `prompt` went missing. Change both, or neither.
 echo '🔒 Verifying brokered identity stays within beta...'
 MH_ISSUER='https://auth.beta.maxhealth.tech'
 # Hosts that must never appear in a beta IdP config (production identity + API).
@@ -335,7 +341,9 @@ if [ -n "${KC_IP:-}" ]; then
     "pkceEnabled": "true",
     "pkceMethod": "S256",
     "defaultScopes": "openid profile email",
-    "syncMode": "FORCE"
+    "syncMode": "FORCE",
+    "prompt": "select_account",
+    "logoutUrl": "${MH_ISSUER}/logout"
   }
 }
 JSON

--- a/docs/admin-ui/identity-providers.md
+++ b/docs/admin-ui/identity-providers.md
@@ -31,6 +31,25 @@ Click **Add Identity Provider** to configure a new external authentication sourc
 
 The remaining fields live in the provider's `config` object and depend on its protocol. OIDC providers take the authorization, token, and logout URLs, a client ID and secret, the issuer and JWKS URL, and the scopes and PKCE method to request. SAML providers take the SSO service URL and entity ID, the signing and encryption certificates, and the NameID format and binding type.
 
+Keys the form does not list are passed through to Keycloak unchanged, so a
+provider can carry anything its type supports.
+
+### Signing out and picking a different account
+
+Two OIDC keys decide what happens after a user signs out, and leaving both unset
+produces a confusing result: the user signs out, clicks the provider again, and
+is returned to the same account with no prompt.
+
+| Key | Effect |
+|---|---|
+| `prompt` | Sent on every authorization request. `select_account` makes the provider offer its account chooser instead of silently reusing its session; `login` forces a full re-authentication |
+| `logoutUrl` | The provider's `end_session_endpoint`, so signing out of Keycloak can end the session at the provider too |
+
+Ending the upstream session depends on how the provider's logout endpoint
+identifies the session. One that reads a browser cookie cannot be ended by a
+server-side call, so `logoutUrl` alone may not be enough; `prompt` is what
+reliably lets a user choose a different account.
+
 ## Claim Mappers
 
 A user who authenticates through an external IdP arrives in Keycloak with only


### PR DESCRIPTION
Companion to [maxhealth.tech@6c7d87d](https://github.com/Max-Health-Inc/maxhealth.tech/commit/6c7d87d), which is where the actual fix lives.

## The bug

After signing out of Proxy Smart, clicking "Login with Max Health" returned the user to the **same account** with no chance to pick another.

The `maxhealth` broker carried no `prompt`, so Keycloak's redirect to `/authorize` arrived with the Max Health SSO cookie still valid, and the auth server issued a code without any interaction. Logout had ended the Keycloak session but never the upstream one, because no `logoutUrl` was configured either.

The upstream was never at fault: `workers/auth` already honours `prompt=login` and `prompt=select_account`, and exposes `/logout` as its `end_session_endpoint`. Keycloak was simply never told to use either.

## Why this repo needs a change at all

The broker is defined **twice** — authoritatively in `scripts/register-maxhealth-idp.ts` in maxhealth.tech, and again as a hardcoded payload in `deploy-beta-remote.sh`. That payload is `PUT` on every beta deploy and overwrites the whole representation, so `prompt` would have been stripped back out within one deploy of being added.

This adds the two keys here to match, and states above the payload that it is a second definition and both must change together.

Removing the duplication would be the better fix. I did not, because this block also self-heals an IdP repointed by hand — something realm import cannot do, since it is `IGNORE_EXISTING` — so retiring it is a separate decision rather than a side effect of a bug fix.

## `logoutUrl` is only half a fix

Worth being explicit: it will not end the upstream session on its own. Logout here is a deliberate **server-side** call ([oauth.ts:542](https://github.com/Max-Health-Inc/proxy-smart/blob/develop/backend/src/routes/auth/oauth.ts#L542)), so Keycloak's logout pages stay off the public proxy — and the Max Health `/logout` identifies the session by reading the browser's SSO cookie, which a server-side call does not carry. Finishing that needs a frontchannel redirect or a backchannel logout endpoint.

`prompt` is what actually fixes the reported symptom.

## Verification

`register-maxhealth-idp.ts --dry-run` against live beta discovery emits `"prompt":"select_account"` and `"logoutUrl":"https://auth.beta.maxhealth.tech/logout"`, the latter read from the discovery document rather than written down. Shell syntax checked; `check:badges` and `check:docs` pass.

## After merge

The broker is not updated by merging this. Someone has to run the provisioning command per environment — including **production**, which has no equivalent auto-reconcile:

```bash
PROXY_SMART_URL=https://proxy-smart.com MAXHEALTH_AUTH_URL=https://auth.maxhealth.tech \
  bun run scripts/register-maxhealth-idp.ts
```