### PR TITLE
fix: push the Keycloak base image so the realm overlay can resolve it

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -146,16 +146,21 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       # Base carries the theme, feature flags and `kc.sh build` output, and no
-      # realm. Loaded locally rather than pushed: only the realm-bearing image
-      # is worth publishing.
-      - name: Build keycloak base image (no realm)
+      # realm.
+      #
+      # Pushed under its own tag rather than kept local. `load: true` puts an
+      # image in the runner's Docker daemon, but the overlay below builds on a
+      # docker-container buildx driver, which resolves FROM against a registry
+      # and never reads that daemon — so it looked for the base on Docker Hub
+      # and failed with "pull access denied". Same repository, distinct tag, so
+      # this needs no extra registry setup.
+      - name: Build & push keycloak base image (no realm)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.keycloak
-          load: true
-          push: false
-          tags: proxy-smart-keycloak-base:beta-${{ inputs.app_version }}
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}/keycloak:base-beta-${{ inputs.app_version }}
           cache-from: type=gha,scope=beta-keycloak
           cache-to: type=gha,mode=max,scope=beta-keycloak
 
@@ -172,7 +177,7 @@ jobs:
             ${{ env.IMAGE_PREFIX }}/keycloak:beta-${{ inputs.app_version }}
             ${{ env.IMAGE_PREFIX }}/keycloak:beta-latest
           build-args: |
-            BASE_IMAGE=proxy-smart-keycloak-base:beta-${{ inputs.app_version }}
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/keycloak:base-beta-${{ inputs.app_version }}
 
   # ── Deploy to VPS via SSH ──
   deploy:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -159,19 +159,23 @@ jobs:
       # Two stages, because the realm is not part of the product.
       #
       # The base carries the theme, the feature flags and the `kc.sh build`
-      # output, and ships no realm at all. It is loaded into the local daemon
-      # rather than pushed: only the finished, realm-bearing image belongs in
-      # ECR, and publishing a realm-less Keycloak would just invite someone to
-      # deploy it.
-      - name: Build Keycloak base image (no realm)
+      # output, and ships no realm at all.
+      #
+      # It is pushed under its own tag rather than kept local. `load: true` puts
+      # an image in the runner's Docker daemon, but the overlay below builds on
+      # a docker-container buildx driver, which resolves FROM against a registry
+      # and never reads that daemon — so it looked for the base on Docker Hub
+      # and failed with "pull access denied". Same ECR repository, distinct tag,
+      # so no second repository or IAM change is needed. Nothing deploys this
+      # tag: the task definition is pointed at the realm-bearing one below.
+      - name: Build and push Keycloak base image (no realm)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.keycloak
-          load: true
-          push: false
+          push: true
           platforms: linux/amd64
-          tags: proxy-smart-keycloak-base:${{ inputs.app_version }}
+          tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_KEYCLOAK_REPOSITORY }}:base-${{ inputs.app_version }}
           build-args: |
             KC_RELATIVE_PATH=/
           cache-from: type=gha,scope=prod-keycloak
@@ -192,7 +196,7 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_KEYCLOAK_REPOSITORY }}:latest
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_KEYCLOAK_REPOSITORY }}:${{ inputs.app_version }}
           build-args: |
-            BASE_IMAGE=proxy-smart-keycloak-base:${{ inputs.app_version }}
+            BASE_IMAGE=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_KEYCLOAK_REPOSITORY }}:base-${{ inputs.app_version }}
 
       # Point the Keycloak task definition at the image we just pushed.
       #

--- a/config/eslint/package.json
+++ b/config/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/eslint-config",
-  "version": "0.3.29-alpha.202608282230.0be408206",
+  "version": "0.3.29-beta.202608282230.0be408206",
   "private": true,
   "type": "module",
   "exports": {

--- a/frontend/smart-dicom-template/package.json
+++ b/frontend/smart-dicom-template/package.json
@@ -3,7 +3,7 @@
   "displayName": "SMART DICOM Algorithm Template",
   "description": "Starter kit for building SMART on FHIR imaging algorithm apps. Clone, implement your algorithm in src/algorithm.ts, and deploy as a SMART app.",
   "private": true,
-  "version": "0.3.29-alpha.202608282230.0be408206",
+  "version": "0.3.29-beta.202608282230.0be408206",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5180",

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Admin UI",
   "description": "A web-based administration interface for managing healthcare applications and resources via Proxy Smart.",
   "private": true,
-  "version": "0.3.29-alpha.202608282230.0be408206",
+  "version": "0.3.29-beta.202608282230.0be408206",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/app-store/package.json
+++ b/packages/app-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/app-store",
-  "version": "0.3.29-alpha.202608282230.0be408206",
+  "version": "0.3.29-beta.202608282230.0be408206",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR app store — manifest discovery, visibility configuration, and registry CRUD. Framework-agnostic.",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/auth",
-  "version": "0.3.29-alpha.202608282230.0be408206",
+  "version": "0.3.29-beta.202608282230.0be408206",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR STU 2.2.0 server-side authorization proxy — launch context, session management, token enrichment. Framework-agnostic, IdP-pluggable.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/cli",
-  "version": "0.3.29-alpha.202608282230.0be408206",
+  "version": "0.3.29-beta.202608282230.0be408206",
   "private": false,
   "type": "module",
   "description": "Admin CLI for the proxy-smart SMART on FHIR authorization proxy. Authenticates via Keycloak OAuth (device flow or client_credentials) and drives the admin REST API.",

--- a/packages/elysia-mcp/package.json
+++ b/packages/elysia-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@max-health-inc/elysia-mcp",
-  "version": "0.3.29-alpha.202608282230.0be408206",
+  "version": "0.3.29-beta.202608282230.0be408206",
   "private": false,
   "type": "module",
   "description": "Auto-generate MCP tools and resources from Elysia routes via introspection. TypeBox-to-Standard-Schema bridge, Streamable HTTP transport, session management.",

--- a/packages/patient-picker/package.json
+++ b/packages/patient-picker/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Patient Picker",
   "description": "Patient selection UI shown during SMART standalone launch when patient context is needed.",
   "private": true,
-  "version": "0.3.29-alpha.202608282230.0be408206",
+  "version": "0.3.29-beta.202608282230.0be408206",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5176",

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/e2e",
-  "version": "0.3.29-alpha.202608282230.0be408206",
+  "version": "0.3.29-beta.202608282230.0be408206",
   "private": true,
   "description": "End-to-end Playwright tests for Proxy Smart apps",
   "scripts": {


### PR DESCRIPTION
Fixes the beta deploy failure introduced by #1082. My bug.

## What broke

```
proxy-smart-keycloak-base:beta-<version>: failed to resolve source metadata for
docker.io/library/proxy-smart-keycloak-base:...: pull access denied
```

`load: true` puts the base image in the runner's Docker daemon. The overlay is a **second** buildx invocation on the `docker-container` driver, which resolves `FROM` against a registry and never reads that daemon — so an unqualified name resolved to Docker Hub, where it does not exist.

The infra checkout and the base build both succeeded, so the cross-repo half of #1082 is proven on beta as well as prod. Only the handoff between the two builds was wrong.

## Fix

Each plane pushes the base under its own tag in the repository it already uses, and the overlay takes that fully qualified reference:

| Plane | Base tag |
|---|---|
| beta | `ghcr.io/max-health-inc/proxy-smart/keycloak:base-beta-<version>` |
| prod | `<ecr>/proxy-smart-keycloak:base-<version>` |

Same repository in both cases, so no second registry, no new ECR repo, no IAM change — and both jobs have already authenticated by that point.

I originally kept the base local on the argument that publishing a realm-less Keycloak invites someone to deploy it. That is worth less than a working build, and both registries are private. Nothing deploys the base tag: the ECS task definition is still pointed at the realm-bearing image via `keycloakImageUri`.

## Production had the same defect

It just had not run yet — the last production deploy predates #1082. This fixes both rather than leaving prod to fail on its next release.

## Verification

The failure and its cause are established from the run log rather than inferred. YAML parses for both workflows; no unqualified base references remain; `keycloakImageUri` still resolves to the version tag, not the base tag.

Genuinely proving it needs a beta deploy, since the failure only appears with a real registry and builder.