### PR TITLE
fix(theme): stop the error page's only link being a 403

### DIFF
--- a/keycloak/themes/proxy-smart/login/error.ftl
+++ b/keycloak/themes/proxy-smart/login/error.ftl
@@ -10,12 +10,17 @@
             </#if>
             <#if skipLink??>
             <#else>
+                <#-- The fallback used to be href="/". On this host that is Keycloak's own root,
+                     which the load balancer serves 403 for — it only exposes /realms/* — so the
+                     one link on the error page was a dead end. PROXY_PUBLIC_URL is the app
+                     origin, reaching a static theme the same way brand-accent.js gets it. With
+                     it unset Keycloak emits the placeholder verbatim, so require an absolute
+                     http(s) URL and render no link at all rather than another dead one. -->
+                <#assign appHome = properties.backToApplicationUrl!"">
                 <#if client?? && client.baseUrl?has_content>
                     <p><a id="backToApplication" href="${client.baseUrl}">${msg("backToApplication")}</a></p>
-                <#else>
-                    <#-- When the auth session cookie is expired, KC doesn't know the client.
-                         Redirect to the origin root which always hits the proxy/app. -->
-                    <p><a id="backToApplication" href="/">&laquo; Back to application</a></p>
+                <#elseif appHome?starts_with("http")>
+                    <p><a id="backToApplication" href="${appHome}">${msg("backToApplication")}</a></p>
                 </#if>
             </#if>
         </div>

--- a/keycloak/themes/proxy-smart/login/theme.properties
+++ b/keycloak/themes/proxy-smart/login/theme.properties
@@ -12,4 +12,9 @@ styles=css/styles.css css/brand.css css/idp-icons.css
 # with it unset Keycloak emits this placeholder verbatim, and brand-accent.js ignores any
 # base that is not an absolute http(s) URL and falls back to same-origin.
 scripts=js/brand-accent.js?base=${env.PROXY_PUBLIC_URL}
+
+# Where "Back to application" goes on the error page when Keycloak no longer knows which
+# client the user came from — an expired auth session, or a failure inside the identity
+# broker. Same substitution, same reason as the script base above.
+backToApplicationUrl=${env.PROXY_PUBLIC_URL}
 stylesCommon=vendor/patternfly-v5/patternfly.min.css vendor/patternfly-v5/patternfly-addons.css


### PR DESCRIPTION
## What you see

Hit any login error and the page offers one action, "« Back to application". It goes to a **403 Forbidden**.

## Why

`error.ftl` had two branches. The fallback, taken whenever Keycloak no longer knows which client the user came from — an expired auth session, or a failure inside the identity broker — was:

```ftl
<#-- When the auth session cookie is expired, KC doesn't know the client.
     Redirect to the origin root which always hits the proxy/app. -->
<p><a id="backToApplication" href="/">&laquo; Back to application</a></p>
```

The intent is right; the assumption isn't. On this host `/` is **Keycloak's own root**, and the load balancer in front of it exposes only `/realms/*`. Verified live:

| path | status |
|---|---|
| `auth.proxy-smart.com/realms/proxy-smart/.well-known/openid-configuration` | 200 |
| `auth.proxy-smart.com/` | 403 |
| `auth.proxy-smart.com/admin` | 403 |

So the one thing offered to a user who has just hit an error is a dead end.

A useful tell: that branch hardcoded English rather than `msg("backToApplication")`, so a screenshot showing "« Back to application" proves the fallback fired and `client.baseUrl` was empty.

## The fix

`PROXY_PUBLIC_URL` is the app origin and already reaches this theme through the same `${env.X}` substitution `brand-accent.js` uses for its script base, so the fallback points there.

With it unset Keycloak emits the placeholder verbatim, so the link renders only for an absolute `http(s)` URL — matching how `brand-accent.js` already ignores a non-absolute base. No link beats another dead one.

## Deployment note

`docker-compose.beta.yml` sets `PROXY_PUBLIC_URL: https://beta.proxy-smart.com`, so beta gets a working link immediately. `docker-compose.prod.yml` is the self-host template (`KC_HOSTNAME: localhost`, "supply your own realm") and is left alone deliberately.

For the hosted production Keycloak, whoever owns that deployment should confirm `PROXY_PUBLIC_URL` is set to the app origin. Until then this change turns a 403 into no link, which is the safe direction but not yet the useful one.

## Also worth doing separately

Clients registered through the admin API get `launch_url` as an attribute but no Keycloak `rootUrl`/`baseUrl`, so the *good* branch above can never fire for them. Mapping `launchUrl` onto `baseUrl` at registration would fix the link properly for known clients, rather than relying on the fallback. Not in this PR.
