### PR TITLE
ci: gate deploys on the theme's ${env.X} actually being set

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -163,6 +163,11 @@ jobs:
           path: infra
           token: ${{ steps.app-token.outputs.token }}
 
+      # See deploy-production. Beta's Keycloak environment is in docker-compose.beta.yml, which
+      # is scp'd to the VPS further down, so the check runs against that rather than infra.
+      - name: Assert the Keycloak environment provides what the theme needs
+        run: node scripts/check-theme-env.mjs docker-compose.beta.yml
+
       # Base carries the theme, feature flags and `kc.sh build` output, and no
       # realm.
       #

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -172,6 +172,14 @@ jobs:
           path: infra
           token: ${{ steps.infra-app-auth.outputs.token }}
 
+      # Fail here rather than serve a broken theme. Keycloak substitutes ${env.X} in
+      # theme.properties at theme load, and an UNSET variable is emitted verbatim — it does not
+      # fail or warn. That is how the error page's "Back to application" came to be a 403: the
+      # fallback had no configured destination and nothing said so. The requirement is read out
+      # of the theme itself, so adding a placeholder makes it a deploy gate automatically.
+      - name: Assert the Keycloak environment provides what the theme needs
+        run: node scripts/check-theme-env.mjs infra
+
       # Two stages, because the realm is not part of the product.
       #
       # The base carries the theme, the feature flags and the `kc.sh build`

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "check": "bun run typecheck && bun run lint && bun run check:badges && bun run check:docs && bun run check:docs:coverage",
+    "check": "bun run typecheck && bun run lint && bun run check:theme-env && bun run check:badges && bun run check:docs && bun run check:docs:coverage",
     "check:badges": "doccheck badges",
     "check:badges:online": "doccheck badges --online",
     "check:docs": "doccheck examples",
@@ -127,7 +127,8 @@
     "version:check": "node scripts/version.js check",
     "version:base": "node scripts/version.js base",
     "precommit": "bun run version:sync",
-    "generate:clients:api": "cd packages/api-client && bun run build"
+    "generate:clients:api": "cd packages/api-client && bun run build",
+    "check:theme-env": "node scripts/check-theme-env.mjs docker-compose.beta.yml"
   },
   "type": "module",
   "workspaces": [

--- a/scripts/check-theme-env.mjs
+++ b/scripts/check-theme-env.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Assert every `${env.X}` a login theme depends on is actually set where that theme is deployed.
+ *
+ * Keycloak substitutes `${env.NAME}` in theme.properties at theme load. When NAME is unset it
+ * does not fail, or warn — it emits the placeholder verbatim, and the theme silently renders
+ * something wrong. That is how the error page's only link came to be a 403: the fallback had no
+ * configured destination and nothing anywhere said so.
+ *
+ * The theme is the source of truth. This reads the placeholders back out of it rather than
+ * keeping a hand-written list, so adding a new `${env.X}` to a theme automatically becomes a
+ * deploy requirement instead of a thing someone has to remember.
+ *
+ * Targets are the files that define the Keycloak container's environment for one deployment:
+ * docker-compose.beta.yml for the VPS, the Keycloak stack in proxy-smart-infra for ECS. The
+ * infra ones live in a private repo that CI checks out to infra/, which is why this takes paths
+ * rather than assuming any.
+ *
+ *   node scripts/check-theme-env.mjs docker-compose.beta.yml
+ *   node scripts/check-theme-env.mjs infra/lib infra/bin
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, extname } from 'node:path';
+
+const THEMES_DIR = 'keycloak/themes';
+const SEARCHABLE = new Set(['.ts', '.js', '.mjs', '.yml', '.yaml', '.json', '.tf', '.env']);
+
+function walk(path, keep) {
+  if (!statSync(path, { throwIfNoEntry: false })?.isDirectory()) return [path];
+  return readdirSync(path, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) return [];
+    const child = join(path, entry.name);
+    if (entry.isDirectory()) return walk(child, keep);
+    return keep(child) ? [child] : [];
+  });
+}
+
+/** Every `${env.NAME}` any theme.properties depends on, with the themes that want it. */
+function requiredEnv() {
+  const required = new Map();
+  for (const file of walk(THEMES_DIR, (f) => f.endsWith('theme.properties'))) {
+    // Comments in a .properties file explain the placeholders, so they mention them too.
+    const declarations = readFileSync(file, 'utf8')
+      .split(/\r?\n/)
+      .filter((line) => !line.trimStart().startsWith('#'))
+      .join('\n');
+    for (const [, name] of declarations.matchAll(/\$\{env\.([A-Z0-9_]+)\}/g)) {
+      if (!required.has(name)) required.set(name, new Set());
+      required.get(name).add(file);
+    }
+  }
+
+  return required;
+}
+
+/**
+ * Whether a target actually ASSIGNS the variable.
+ *
+ * A mention is not an assignment — every one of these files also names the variable in a
+ * comment explaining what it is for — so require a `:` or `=` and a non-empty value after it.
+ */
+function assignsVariable(text, name) {
+  return text.split(/\r?\n/).some((line) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('#') || trimmed.startsWith('//')) return false;
+    const at = trimmed.indexOf(name);
+    if (at === -1) return false;
+    const after = trimmed.slice(at + name.length).replace(/^["'`]/, '').trimStart();
+    if (!after.startsWith(':') && !after.startsWith('=')) return false;
+    return after.slice(1).trim().length > 0;
+  });
+}
+
+const targets = process.argv.slice(2);
+if (targets.length === 0) {
+  console.error('usage: check-theme-env.mjs <file-or-directory>...');
+  process.exit(2);
+}
+
+const files = targets.flatMap((target) => walk(target, (f) => SEARCHABLE.has(extname(f))));
+const haystack = files.map((f) => readFileSync(f, 'utf8')).join('\n');
+
+const missing = [];
+for (const [name, themes] of requiredEnv()) {
+  if (!assignsVariable(haystack, name)) missing.push({ name, themes: [...themes] });
+}
+
+if (missing.length > 0) {
+  console.error(`✖ Theme environment not provided by ${targets.join(', ')}:\n`);
+  for (const { name, themes } of missing) {
+    console.error(`  ${name} — required by ${themes.join(', ')}`);
+  }
+  console.error('\nKeycloak emits an unset ${env.X} verbatim, so the theme would render a broken');
+  console.error('value rather than fail. Set it on the Keycloak container for this deployment.');
+  process.exit(1);
+}
+
+const names = [...requiredEnv().keys()];
+console.log(`✔ ${names.length ? names.join(', ') : 'no theme environment'} provided by ${targets.join(', ')} (${files.length} files)`);


### PR DESCRIPTION
Follow-up to #1120, which fixed the dead "Back to application" link but left a manual step behind — *"remember to set `PROXY_PUBLIC_URL` on the production Keycloak"*. That is the same class of thing that produced the bug.

## Why a gate

Keycloak substitutes `${env.X}` in `theme.properties` at theme load. When the variable is unset it does **not** fail and does **not** warn — it emits the placeholder verbatim and the theme renders a broken value. Nothing surfaces it, which is why that link could point at a 403 for as long as it did.

## What it does

`scripts/check-theme-env.mjs` reads the requirement out of the **theme**, not a hand-written list, so adding a placeholder to any theme automatically becomes a deploy requirement.

Two details that matter for it being trustworthy rather than noisy:

- It asserts **assignment**, not mention. Every one of these files also names the variable in a comment explaining it, so a substring match would pass on documentation alone.
- It **skips comment lines** when collecting placeholders. The first version didn't, and dutifully demanded a variable called `X` because `theme.properties` has a comment reading "Keycloak substitutes `${env.X}` here".

Verified in all three directions, including against the real private infra repo:

```
$ node scripts/check-theme-env.mjs docker-compose.beta.yml
✔ PROXY_PUBLIC_URL provided by docker-compose.beta.yml (1 files)      exit 0

$ node scripts/check-theme-env.mjs <proxy-smart-infra checkout>
✔ PROXY_PUBLIC_URL provided by ... (18 files)                          exit 0

$ node scripts/check-theme-env.mjs docker-compose.caddy.yml
✖ Theme environment not provided by docker-compose.caddy.yml:
    PROXY_PUBLIC_URL — required by keycloak/themes/proxy-smart/login/theme.properties
                                                                       exit 1
```

## Where it runs

Wired where each environment's Keycloak environment actually lives:

| workflow | target |
|---|---|
| `deploy-beta` | `docker-compose.beta.yml`, which it scp's to the VPS |
| `deploy-production` | `infra`, the `proxy-smart-infra` CDK it already checks out |
| `check` | the beta compose, so a theme change fails on the PR rather than at deploy |

## Production is already configured — correcting my earlier claim

An earlier version of this description said production had been running without the variable and should expect to fail this gate. **That was wrong**, and it was wrong because I concluded it from the public repo alone.

`proxy-smart-infra` sets it properly:

```ts
// lib/keycloak-stack.ts
PROXY_PUBLIC_URL: props.proxyPublicUrl,

// bin/infra.ts
proxyPublicUrl: `https://${config.backendDomain}`,
backendDomain: app.node.tryGetContext('backendDomain') || 'api.proxy-smart.com',
```

So production resolves it to `https://api.proxy-smart.com` (200), and #1120's fallback will work there as soon as it deploys. There is nothing to change in the infra repo.

That leaves this PR as pure regression insurance rather than a fix for a live gap — it keeps the variable from being dropped later, and covers any future `${env.X}` a theme adds.

`docker-compose.prod.yml` is deliberately untouched: it's the self-host template (`KC_HOSTNAME: localhost`, "supply your own realm"), and its localhost value is correct for what it is.