### PR TITLE
fix(idp): check what a mapper DOES, not just that one exists

### DIFF
--- a/backend/src/lib/idp-mappers.ts
+++ b/backend/src/lib/idp-mappers.ts
@@ -222,7 +222,9 @@ export interface IdpMapperStatus {
   missingRequired: string[]
   /** Names of optional definitions with no matching mapper */
   missingOptional: string[]
-  /** True when every required attribute import is present */
+  /** Definitions whose mapper EXISTS but does not do what the definition asks */
+  misconfigured: { name: string; mapper: string; differences: string[] }[]
+  /** True when every required attribute import is present AND correctly configured */
   healthy: boolean
   /** True when the provider supports no attribute-import mapper type */
   unsupported: boolean
@@ -230,9 +232,46 @@ export interface IdpMapperStatus {
   userFacing: boolean
 }
 
-/** A definition is satisfied by any mapper writing the same user attribute. */
-const isSatisfied = (definition: IdpAttributeMapperDefinition, mappers: IdpMapperEntry[]): boolean =>
-  mappers.some((mapper) => mapper.userAttribute === definition.userAttribute)
+/**
+ * The mapper serving a definition, matched on the TARGET user attribute.
+ *
+ * Deliberately not matched on name: an admin who renames a mapper has not removed it, and
+ * provisioning a second mapper writing the same attribute would be worse than the rename.
+ */
+const findMapperFor = (
+  definition: IdpAttributeMapperDefinition,
+  mappers: IdpMapperEntry[],
+): IdpMapperEntry | undefined =>
+  mappers.find((mapper) => mapper.userAttribute === definition.userAttribute)
+
+/**
+ * How an existing mapper differs from what its definition asks for. Empty means it is correct.
+ *
+ * EXISTENCE USED TO BE THE WHOLE CHECK, and that is how `fhirUser-import` ran in production
+ * with syncMode IMPORT while the definition demanded FORCE. IMPORT writes the attribute only
+ * when the brokered user is first created, so a member who signed in BEFORE their health
+ * record existed never received `fhirUser` — not on that login and not on any later one,
+ * which reads to them as "your health record isn't set up yet", permanently. The status
+ * endpoint called the provider healthy throughout, because a mapper writing the right
+ * attribute was present, and `ensureIdpAttributeMappers` skipped it for the same reason, so
+ * running the fix endpoint could never repair it either.
+ *
+ * Only `syncMode` is compared, and only where the mapper type carries one. The CLAIM is
+ * deliberately not: a federated IdP may legitimately publish the reference under its own name
+ * — `smart_fhir_user`, say — and an admin who wired that up has configured it correctly, so
+ * "correcting" it would break a working provider. What the proxy actually requires is the
+ * target attribute (which identifies the mapper) and that the value refreshes on every login.
+ * A field the type does not support is skipped, because a check that cannot go green is one
+ * people learn to ignore.
+ */
+function mapperDrift(
+  definition: IdpAttributeMapperDefinition,
+  mapper: IdpMapperEntry,
+  supportsSyncMode: boolean,
+): string[] {
+  if (!supportsSyncMode || mapper.syncMode === definition.syncMode) return []
+  return [`syncMode is ${mapper.syncMode ?? '(unset)'}, expected ${definition.syncMode}`]
+}
 
 /**
  * Whether humans are brokered through this provider.
@@ -274,13 +313,22 @@ export async function getIdpMapperStatus(
   const userFacing = isUserFacingProvider(provider)
   const missingRequired: string[] = []
   const missingOptional: string[] = []
+  const misconfigured: IdpMapperStatus['misconfigured'] = []
 
   // Only providers humans log in through need user attribute imports.
   if (userFacing) {
     for (const definition of SMART_IDP_ATTRIBUTE_MAPPERS) {
-      if (isSatisfied(definition, mappers)) continue
-      if (definition.required) missingRequired.push(definition.name)
-      else missingOptional.push(definition.name)
+      const mapper = findMapperFor(definition, mappers)
+      if (!mapper) {
+        if (definition.required) missingRequired.push(definition.name)
+        else missingOptional.push(definition.name)
+        continue
+      }
+
+      const differences = mapperDrift(definition, mapper, attributeType?.supportsSyncMode ?? false)
+      if (differences.length > 0) {
+        misconfigured.push({ name: definition.name, mapper: mapper.name, differences })
+      }
     }
   }
 
@@ -295,9 +343,14 @@ export async function getIdpMapperStatus(
     mappers,
     missingRequired,
     missingOptional,
+    misconfigured,
     // Neither a machine trust anchor nor a provider that cannot carry attribute
     // mappers at all is "unhealthy" — there is no action an admin could take.
-    healthy: unsupported || !userFacing || missingRequired.length === 0,
+    //
+    // A misconfigured mapper counts as unhealthy even when it is optional: it EXISTS, so an
+    // admin looking at the list sees the attribute covered, and the whole failure mode here
+    // is a wrong mapper reading as a present one.
+    healthy: unsupported || !userFacing || (missingRequired.length === 0 && misconfigured.length === 0),
     unsupported,
     userFacing,
   }
@@ -317,7 +370,9 @@ export interface EnsureIdpMappersResult {
   attributeMapperType: string | null
   /** Names of mappers created by this call */
   created: string[]
-  /** Names of definitions that already had a matching mapper */
+  /** Names of mappers that existed but were corrected in place by this call */
+  repaired: string[]
+  /** Names of definitions already served by a correctly configured mapper */
   skipped: string[]
   /** True when the provider supports no attribute-import mapper type */
   unsupported: boolean
@@ -327,10 +382,15 @@ export interface EnsureIdpMappersResult {
 }
 
 /**
- * Ensure the SMART attribute-import mappers exist on an identity provider.
+ * Ensure the SMART attribute-import mappers exist AND are configured correctly.
  *
- * Idempotent: a definition already served by an existing mapper (matched on the
- * target user attribute, so admin-renamed mappers still count) is skipped.
+ * Idempotent: a definition already served by a correct mapper (matched on the target user
+ * attribute, so admin-renamed mappers still count) is skipped. One that exists but has
+ * drifted is corrected IN PLACE rather than skipped — this used to only ever create missing
+ * mappers, which is why the fix endpoint could not repair `fhirUser-import` running on
+ * syncMode IMPORT. Repairing in place also avoids the alternative failure, two mappers
+ * writing the same user attribute.
+ *
  * Machine trust anchors are left alone — see isUserFacingProvider.
  *
  * @param includeOptional also provision definitions marked optional
@@ -344,6 +404,7 @@ export async function ensureIdpAttributeMappers(
     alias,
     attributeMapperType: null,
     created: [],
+    repaired: [],
     skipped: [],
     unsupported: false,
     userFacing: true,
@@ -375,12 +436,39 @@ export async function ensureIdpAttributeMappers(
     : SMART_IDP_ATTRIBUTE_MAPPERS.filter((definition) => definition.required)
 
   for (const definition of definitions) {
-    if (isSatisfied(definition, existingEntries)) {
+    const current = findMapperFor(definition, existingEntries)
+    const differences = current ? mapperDrift(definition, current, attributeType.supportsSyncMode) : []
+
+    if (current && differences.length === 0) {
       result.skipped.push(definition.name)
       continue
     }
 
     try {
+      if (current?.id) {
+        // Merge rather than rebuild. buildAttributeMapper would rewrite the claim to the
+        // definition's, discarding an admin's deliberate mapping from a provider that
+        // publishes the reference under another name. Only the drifted keys move.
+        await admin.identityProviders.updateMapper(
+          { alias, id: current.id },
+          {
+            id: current.id,
+            name: current.name || definition.name,
+            identityProviderAlias: alias,
+            identityProviderMapper: current.identityProviderMapper || attributeType.id,
+            config: { ...current.config, syncMode: definition.syncMode },
+          },
+        )
+        result.repaired.push(definition.name)
+        logger.admin.info('Repaired IdP attribute mapper', {
+          alias,
+          mapper: current.name,
+          userAttribute: definition.userAttribute,
+          differences,
+        })
+        continue
+      }
+
       await admin.identityProviders.createMapper({
         alias,
         identityProviderMapper: buildAttributeMapper(alias, definition, attributeType),

--- a/backend/src/schemas/admin/identity-providers.ts
+++ b/backend/src/schemas/admin/identity-providers.ts
@@ -177,7 +177,15 @@ export const IdentityProviderMapperStatus = t.Object({
   mappers: t.Array(IdentityProviderMapperResponse, { description: 'Mappers currently attached to the provider' }),
   missingRequired: t.Array(t.String(), { description: 'Names of required mappers that are missing' }),
   missingOptional: t.Array(t.String(), { description: 'Names of optional mappers that are missing' }),
-  healthy: t.Boolean({ description: 'Whether all required attribute imports are present' }),
+  misconfigured: t.Array(
+    t.Object({
+      name: t.String({ description: 'Definition the mapper is meant to satisfy' }),
+      mapper: t.String({ description: 'Name the mapper carries in Keycloak' }),
+      differences: t.Array(t.String(), { description: 'What differs, as "field is X, expected Y"' })
+    }),
+    { description: 'Mappers that EXIST but do not do what their definition asks — e.g. syncMode IMPORT where FORCE is required, which stops later logins refreshing the attribute' }
+  ),
+  healthy: t.Boolean({ description: 'Whether all required attribute imports are present AND correctly configured' }),
   unsupported: t.Boolean({ description: 'Whether the provider supports attribute-import mappers at all' }),
   userFacing: t.Boolean({
     description: 'False for machine trust anchors (client-assertion federation), where user attributes do not apply'
@@ -197,7 +205,8 @@ export const IdentityProviderMapperFixResponse = t.Object({
   alias: t.String({ description: 'Provider the mappers were provisioned on' }),
   attributeMapperType: t.Union([t.String(), t.Null()], { description: 'Mapper type used for provisioning' }),
   created: t.Array(t.String(), { description: 'Names of mappers created by this call' }),
-  skipped: t.Array(t.String(), { description: 'Names of mappers that already existed' }),
+  repaired: t.Array(t.String(), { description: 'Names of mappers that existed but were corrected in place' }),
+  skipped: t.Array(t.String(), { description: 'Names of mappers already present and correctly configured' }),
   unsupported: t.Boolean({ description: 'Whether the provider supports attribute-import mappers at all' }),
   userFacing: t.Boolean({ description: 'False when the provider is a machine trust anchor; nothing is provisioned' }),
   errors: t.Array(t.String(), { description: 'Any errors encountered' }),

--- a/backend/test/idp-mappers.test.ts
+++ b/backend/test/idp-mappers.test.ts
@@ -85,6 +85,13 @@ interface CreateMapperPayload {
   }
 }
 
+interface UpdateMapperPayload {
+  id?: string
+  name?: string
+  identityProviderMapper?: string
+  config?: Record<string, string>
+}
+
 function createMockAdmin({
   types = OIDC_TYPES,
   mappers = [],
@@ -94,6 +101,8 @@ function createMockAdmin({
 }: MockOptions = {}) {
   /** Payloads passed to createMapper, in call order */
   const createdPayloads: CreateMapperPayload[] = []
+  /** Representations passed to updateMapper, in call order */
+  const updatedPayloads: UpdateMapperPayload[] = []
 
   const identityProviders = {
     findOne: mock(async () => ({ alias: 'hospital-oidc', providerId: 'oidc', config: providerConfig })),
@@ -107,9 +116,17 @@ function createMockAdmin({
       createdPayloads.push(payload)
       return { id: 'created-id' }
     }),
+    updateMapper: mock(async (target: { alias: string; id: string }, representation: UpdateMapperPayload) => {
+      updatedPayloads.push({ ...representation, id: target.id })
+    }),
   }
 
-  return { admin: { identityProviders } as unknown as AdminArg, identityProviders, createdPayloads }
+  return {
+    admin: { identityProviders } as unknown as AdminArg,
+    identityProviders,
+    createdPayloads,
+    updatedPayloads,
+  }
 }
 
 describe('resolveAttributeMapperType', () => {
@@ -193,13 +210,13 @@ describe('ensureIdpAttributeMappers', () => {
     })
   })
 
-  it('is idempotent: an existing mapper for the attribute is skipped even when renamed', async () => {
+  it('is idempotent: a correct mapper for the attribute is skipped even when renamed', async () => {
     const { admin, identityProviders } = createMockAdmin({
       mappers: [{
         id: 'existing',
         name: 'our-own-fhiruser-mapping',
         identityProviderMapper: 'oidc-user-attribute-idp-mapper',
-        config: { claim: 'smart_fhir_user', 'user.attribute': 'fhirUser' },
+        config: { claim: 'smart_fhir_user', 'user.attribute': 'fhirUser', syncMode: 'FORCE' },
       }],
     })
 
@@ -207,7 +224,68 @@ describe('ensureIdpAttributeMappers', () => {
 
     expect(result.skipped).toContain('fhirUser-import')
     expect(result.created).not.toContain('fhirUser-import')
+    expect(identityProviders.updateMapper).not.toHaveBeenCalled()
     expect(identityProviders.createMapper).toHaveBeenCalledTimes(SMART_IDP_ATTRIBUTE_MAPPERS.length - 1)
+  })
+
+  it('repairs a mapper stuck on IMPORT instead of skipping it', async () => {
+    // The production failure: fhirUser-import existed, so every check called the provider
+    // healthy and every fix skipped it, while IMPORT meant the attribute was written once at
+    // user creation and never refreshed. A member who signed in before their record existed
+    // stayed without a fhirUser for good.
+    const { admin, updatedPayloads } = createMockAdmin({
+      mappers: [{
+        id: 'stuck',
+        name: 'fhirUser-import',
+        identityProviderMapper: 'oidc-user-attribute-idp-mapper',
+        config: { claim: 'fhirUser', 'user.attribute': 'fhirUser', syncMode: 'IMPORT' },
+      }],
+    })
+
+    const result = await ensureIdpAttributeMappers(admin, 'hospital-oidc')
+
+    expect(result.repaired).toContain('fhirUser-import')
+    expect(result.skipped).not.toContain('fhirUser-import')
+    expect(updatedPayloads[0]?.id).toBe('stuck')
+    expect(updatedPayloads[0]?.config?.syncMode).toBe('FORCE')
+  })
+
+  it('keeps the admin-configured claim when repairing', async () => {
+    // A provider may publish the reference under its own name. Rebuilding the mapper from the
+    // definition would rewrite that to `fhirUser` and break a working federation, so only the
+    // drifted key moves.
+    const { admin, updatedPayloads } = createMockAdmin({
+      mappers: [{
+        id: 'renamed',
+        name: 'our-own-fhiruser-mapping',
+        identityProviderMapper: 'oidc-user-attribute-idp-mapper',
+        config: { claim: 'smart_fhir_user', 'user.attribute': 'fhirUser', syncMode: 'IMPORT' },
+      }],
+    })
+
+    await ensureIdpAttributeMappers(admin, 'hospital-oidc')
+
+    expect(updatedPayloads[0]?.config?.claim).toBe('smart_fhir_user')
+    expect(updatedPayloads[0]?.config?.syncMode).toBe('FORCE')
+    expect(updatedPayloads[0]?.name).toBe('our-own-fhiruser-mapping')
+  })
+
+  it('leaves syncMode alone on a provider type that has none', async () => {
+    // SAML's importer declares no syncMode, so demanding one would be a permanent false alarm.
+    const { admin, identityProviders } = createMockAdmin({
+      types: SAML_TYPES,
+      mappers: [{
+        id: 'saml-existing',
+        name: 'fhirUser-import',
+        identityProviderMapper: 'saml-user-attribute-idp-mapper',
+        config: { 'attribute.name': 'fhirUser', 'user.attribute': 'fhirUser' },
+      }],
+    })
+
+    const result = await ensureIdpAttributeMappers(admin, 'hospital-saml')
+
+    expect(result.skipped).toContain('fhirUser-import')
+    expect(identityProviders.updateMapper).not.toHaveBeenCalled()
   })
 
   it('provisions only required mappers when optional ones are excluded', async () => {
@@ -285,6 +363,28 @@ describe('getIdpMapperStatus', () => {
     expect(status.missingOptional).toEqual(['organization-import'])
     expect(status.mappers[0]?.externalName).toBe('fhirUser')
     expect(status.mappers[0]?.userAttribute).toBe('fhirUser')
+    expect(status.misconfigured).toEqual([])
+  })
+
+  it('is UNHEALTHY when the required mapper exists but will not refresh', async () => {
+    // Existence was once the whole check, so this exact provider reported healthy while
+    // brokered users silently never had their fhirUser updated after first login.
+    const { admin } = createMockAdmin({
+      mappers: [{
+        id: 'm1',
+        name: 'fhirUser-import',
+        identityProviderMapper: 'oidc-user-attribute-idp-mapper',
+        config: { claim: 'fhirUser', 'user.attribute': 'fhirUser', syncMode: 'IMPORT' },
+      }],
+    })
+
+    const status = await getIdpMapperStatus(admin, provider)
+
+    expect(status.missingRequired).toEqual([])
+    expect(status.healthy).toBe(false)
+    expect(status.misconfigured).toEqual([
+      { name: 'fhirUser-import', mapper: 'fhirUser-import', differences: ['syncMode is IMPORT, expected FORCE'] },
+    ])
   })
 
   it('does not mark providers unhealthy when no attribute importer exists', async () => {

--- a/config/eslint/package.json
+++ b/config/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/eslint-config",
-  "version": "0.4.2-beta.202608292104.162ca334d",
+  "version": "0.4.2-beta.202608292114.585cf6bf1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/api-client",
-  "version": "0.4.2-beta.202608292104.162ca334d",
+  "version": "0.4.2-beta.202608292114.585cf6bf1",
   "private": false,
   "type": "module",
   "description": "Typed fetch client for the Proxy Smart admin and FHIR API, generated from its OpenAPI spec.",

--- a/packages/app-store/package.json
+++ b/packages/app-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/app-store",
-  "version": "0.4.2-beta.202608292104.162ca334d",
+  "version": "0.4.2-beta.202608292114.585cf6bf1",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR app store — manifest discovery, visibility configuration, and registry CRUD. Framework-agnostic.",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/auth",
-  "version": "0.4.2-beta.202608292104.162ca334d",
+  "version": "0.4.2-beta.202608292114.585cf6bf1",
   "private": false,
   "type": "module",
   "description": "SMART on FHIR STU 2.2.0 server-side authorization proxy — launch context, session management, token enrichment. Framework-agnostic, IdP-pluggable.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/cli",
-  "version": "0.4.2-beta.202608292104.162ca334d",
+  "version": "0.4.2-beta.202608292114.585cf6bf1",
   "private": false,
   "type": "module",
   "description": "Admin CLI for the proxy-smart SMART on FHIR authorization proxy. Authenticates via Keycloak OAuth (device flow or client_credentials) and drives the admin REST API.",

--- a/packages/elysia-mcp/package.json
+++ b/packages/elysia-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/elysia-mcp",
-  "version": "0.4.2-beta.202608292104.162ca334d",
+  "version": "0.4.2-beta.202608292114.585cf6bf1",
   "private": false,
   "type": "module",
   "description": "Auto-generate MCP tools and resources from Elysia routes via introspection. TypeBox-to-Standard-Schema bridge and tool execution; the HTTP edge lives in @maxhealth.tech/mcp-http.",

--- a/packages/patient-picker/package.json
+++ b/packages/patient-picker/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Patient Picker",
   "description": "Patient selection UI shown during SMART standalone launch when patient context is needed.",
   "private": true,
-  "version": "0.4.2-beta.202608292104.162ca334d",
+  "version": "0.4.2-beta.202608292114.585cf6bf1",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5176",

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/e2e",
-  "version": "0.4.2-beta.202608292104.162ca334d",
+  "version": "0.4.2-beta.202608292114.585cf6bf1",
   "private": true,
   "description": "End-to-end Playwright tests for Proxy Smart apps",
   "scripts": {


### PR DESCRIPTION
`syncMode: IMPORT` writes a user attribute **once**, when the brokered user is first created, and never again. For an attribute that does not exist yet at that moment — `fhirUser` being the obvious one, since a user can be federated before their FHIR resource is created — the value is missing on that login and on every login afterwards. Nothing recovers it, so a user in that state can never launch a SMART app no matter how many times they sign in.

`SMART_IDP_ATTRIBUTE_MAPPERS` has always specified `FORCE` for exactly this reason, with the comment *"FORCE re-imports on every login, so upstream changes propagate"*. Nothing enforced it.

## Why a wrong mapper reads as a correct one

```ts
const isSatisfied = (definition, mappers) =>
  mappers.some((mapper) => mapper.userAttribute === definition.userAttribute)
```

A mapper writing the right attribute is present, so:

- `getIdpMapperStatus` reports the provider **healthy**, `missingRequired: []`
- `ensureIdpAttributeMappers` puts it in **`skipped`** — so the fix endpoint cannot repair it either

The one operation an admin would reach for is a no-op on the one thing that is wrong. A provider can sit misconfigured indefinitely while every check says it is fine.

## The change

`IdpMapperStatus` gains `misconfigured` (definition name, the mapper's own name, and what differs) and goes unhealthy for it. `ensureIdpAttributeMappers` repairs in place instead of skipping, and reports `repaired` alongside `created`.

**Only `syncMode` is compared, deliberately.** The claim is not: a federated IdP may publish a value under its own name — `smart_fhir_user`, say — and an admin who wired that up is correct, so "fixing" it would break a working provider. For the same reason the repair **merges** into the existing config rather than rebuilding from the definition, which would have rewritten that claim. Mapper types that declare no `syncMode` (the SAML importer) are left alone rather than flagged forever.

The existing *"an existing mapper is skipped even when renamed"* test is what surfaced that — my first version compared the claim too, and that test failed it. Correctly.

## Tests

New coverage for: a correct renamed mapper still being skipped, a mapper stuck on IMPORT being repaired rather than skipped, the admin's claim surviving the repair, a type without `syncMode` not being flagged, and status going unhealthy with `misconfigured` populated when the required mapper exists but will not refresh.

typecheck and lint clean; 23 tests in `idp-mappers.test.ts`, 45 across the IdP suites.