### PR TITLE
fix(oauth): resolve a Person fhirUser upstream, not through the proxy

### DIFF
--- a/backend/src/routes/auth/oauth.ts
+++ b/backend/src/routes/auth/oauth.ts
@@ -728,8 +728,22 @@ export const oauthRoutes = new Elysia({ tags: ['authentication'] })
               ? `${config.baseUrl}/${config.name}/${firstServer.identifier}/${firstServer.metadata.fhirVersion}`
               : ''
 
+            /*
+             * Read the Person UPSTREAM, not back through the proxy with the app's own token.
+             *
+             * Going through fhirBaseUrl re-enters access control, and a patient-scoped grant is
+             * refused there when the token carries no patient context yet — which is exactly the
+             * state this call exists to resolve. The app cannot read the Person that would
+             * establish its context because it has no context, so a Person fhirUser silently
+             * produced no fhirUser and no patient for every patient-facing app.
+             *
+             * The proxy is the one asking, and it only ever follows a link the Person named in
+             * the token's own claim declares, so it resolves against the server directly. The
+             * reference is still handed back re-based on fhirBaseUrl below: what the app sees
+             * does not change, only who performs the lookup.
+             */
             const resolvedFhirUser = await resolveFhirUserForClient(
-              tokenPayload.fhirUser, clientConfig.patientFacing, fhirBaseUrl,
+              tokenPayload.fhirUser, clientConfig.patientFacing, firstServer?.url || fhirBaseUrl,
               firstServer?.identifier || '', `Bearer ${data.access_token}`
             )
             if (resolvedFhirUser) {


### PR DESCRIPTION
A patient-facing app whose `fhirUser` claim is a **Person** receives no `fhirUser` and no `patient` context at all, so it launches with nothing and reports having no patient.

## The chicken-and-egg

`resolveFhirUserForClient` must read the Person to follow its link to the Patient. It read through `fhirBaseUrl` — the proxy's own FHIR endpoint — carrying the app's freshly minted access token, so the read **re-entered access control**. There, `smart-access-control.ts` refuses a patient-compartment grant that carries no patient context:

```
Patient-scoped token carries no patient context
  → "The grant is confined to one patient but nothing says which"
```

Which is exactly the state this call exists to resolve. The app cannot read the Person that would establish its context, **because it has no context**. Resolution returns `undefined`, the claim is dropped, and `data.patient` can never be derived from it either.

## Why it stayed hidden

A claim that already names the expected type is returned as-is at the top of `resolveFhirUserForClient`, with no FHIR read at all. So any deployment whose stored identities are `Patient/<id>` references never reaches this path. It only appears once identities are genuinely Person-based — which is the design `Person` exists to support, since one Person links to a Patient *and* a Practitioner so a single claim can serve both a patient app and a clinician app.

## The fix

Resolve against the server directly, which is what `upstreamFhirQuery` already does for the ownership check in `smart-access-control.ts`. The **proxy** is the one asking, and it only ever follows a link that the Person named in the token's own claim declares — it cannot reach another subject's data.

`toAbsoluteFhirUser` still re-bases the result on `fhirBaseUrl` before it reaches the client, so what the app sees is unchanged. Only who performs the lookup changes.

## Verification

Backend suite is **unchanged**: 34 failures and 8 errors before my change and after, none new — I ran it on clean `develop` to confirm. `typecheck:backend` likewise reports the same 4 pre-existing `TS7006` errors in `test/shl-consent.test.ts` with and without this change; I left those alone as unrelated.