### PR TITLE
fix(smart-apps): let patientFacing be cleared, not just set

### DIFF
--- a/backend/src/routes/admin/smart-apps.ts
+++ b/backend/src/routes/admin/smart-apps.ts
@@ -314,7 +314,11 @@ export const smartAppsRoutes = new Elysia({ prefix: '/smart-apps', tags: ['smart
           }),
 
           // fhirUser resolution mode
-          ...(body.patientFacing !== undefined && { 'patient_facing': String(body.patientFacing) }),
+          // Empty string clears it, matching the other attributes here, and enrichment reads
+          // anything that is not 'true'/'false' back as undefined — the passthrough default.
+          ...(body.patientFacing !== undefined && {
+            'patient_facing': body.patientFacing === null ? '' : String(body.patientFacing)
+          }),
 
           // Session timeout overrides
           ...(body.clientSessionIdleTimeout !== undefined && { 'client.session.idle.timeout': String(body.clientSessionIdleTimeout) }),
@@ -690,7 +694,11 @@ export const smartAppsRoutes = new Elysia({ prefix: '/smart-apps', tags: ['smart
             'required_roles': body.requiredRoles.length > 0 ? body.requiredRoles.join(',') : ''
           }),
           // fhirUser resolution mode
-          ...(body.patientFacing !== undefined && { 'patient_facing': String(body.patientFacing) }),
+          // Empty string clears it, matching the other attributes here, and enrichment reads
+          // anything that is not 'true'/'false' back as undefined — the passthrough default.
+          ...(body.patientFacing !== undefined && {
+            'patient_facing': body.patientFacing === null ? '' : String(body.patientFacing)
+          }),
           // Metadata fields
           ...(body.launchUrl !== undefined && { 'launch_url': body.launchUrl }),
           ...(body.logoUri !== undefined && { 'logo_uri': body.logoUri }),

--- a/backend/src/schemas/admin/smart-apps.ts
+++ b/backend/src/schemas/admin/smart-apps.ts
@@ -131,7 +131,7 @@ export const CreateSmartAppRequest = t.Object({
   requiredRoles: t.Optional(t.Array(t.String(), { description: 'Realm roles required to access this app. Users without these roles are denied at login.' })),
   
   // fhirUser resolution
-  patientFacing: t.Optional(t.Boolean({ description: 'If true, resolves fhirUser to Patient (from Person links). If false, resolves to Practitioner. If undefined, uses raw fhirUser as-is (backward compat).' })),
+  patientFacing: t.Optional(t.Union([t.Boolean(), t.Null()], { description: 'If true, resolves fhirUser to Patient (from Person links). If false, resolves to Practitioner. Null clears it, restoring the raw-passthrough default for an app that resolves the Person itself or serves both roles. Omit to leave unchanged.' })),
   
   // Consent & scope settings
   consentRequired: t.Optional(t.Boolean({ description: 'Whether the user must explicitly consent to scopes at login' })),
@@ -198,7 +198,7 @@ export const UpdateSmartAppRequest = t.Object({
   requiredRoles: t.Optional(t.Array(t.String(), { description: 'Realm roles required to access this app. Users without these roles are denied at login.' })),
   
   // fhirUser resolution
-  patientFacing: t.Optional(t.Boolean({ description: 'If true, resolves fhirUser to Patient (from Person links). If false, resolves to Practitioner. If undefined, uses raw fhirUser as-is (backward compat).' })),
+  patientFacing: t.Optional(t.Union([t.Boolean(), t.Null()], { description: 'If true, resolves fhirUser to Patient (from Person links). If false, resolves to Practitioner. Null clears it, restoring the raw-passthrough default for an app that resolves the Person itself or serves both roles. Omit to leave unchanged.' })),
   
   // Consent & scope settings
   consentRequired: t.Optional(t.Boolean({ description: 'Whether the user must explicitly consent to scopes at login' })),

--- a/backend/test/smart-apps-attributes.test.ts
+++ b/backend/test/smart-apps-attributes.test.ts
@@ -97,6 +97,25 @@ describe('PUT /smart-apps/:clientId — Keycloak attribute contract', () => {
     expect(nonStringAttributes(updates[0]!.body)).toEqual([])
   })
 
+  it('clears patient_facing when null is sent, so an app can go back to passthrough', async () => {
+    // The resolver has three states — Patient, Practitioner, and raw passthrough for an app that
+    // resolves the Person itself or serves both roles. Only two were reachable: `undefined` on
+    // the request means "leave unchanged", so once set an app could never return to the third.
+    updates.length = 0
+    await app().handle(put({ patientFacing: null }))
+
+    const attrs = updates[0]!.body.attributes as Record<string, unknown>
+    expect(attrs.patient_facing).toBe('')
+    expect(nonStringAttributes(updates[0]!.body)).toEqual([])
+  })
+
+  it('still writes the boolean when one is sent', async () => {
+    updates.length = 0
+    await app().handle(put({ patientFacing: true }))
+
+    expect((updates[0]!.body.attributes as Record<string, unknown>).patient_facing).toBe('true')
+  })
+
   it('preserves an existing version when the field is omitted', async () => {
     updates.length = 0
     await app().handle(put({ patientFacing: false }))


### PR DESCRIPTION
`fhirUser` resolution has **three** states:

| `patientFacing` | behaviour |
|---|---|
| `true` | resolve the Person to its **Patient** link |
| `false` | resolve the Person to its **Practitioner** link |
| *absent* | hand the raw claim through untouched |

The third exists for an app that resolves the Person itself, or that serves **both** roles — where no per-client answer is correct, because the right role depends on the user rather than the app.

The admin API could only ever reach two of them. Both write paths were:

```ts
...(body.patientFacing !== undefined && { 'patient_facing': String(body.patientFacing) })
```

and the schema is `t.Optional(t.Boolean())`, so `undefined` means *"leave unchanged"*. Once an app had the attribute, **it could never go back to passthrough**. An app is only in that third state today by having never been configured at all — not something an operator can choose, or return to after a mistake.

## The change

The two request schemas accept `null`, and `null` writes an empty string.

That is already how every other attribute here clears — `organization_ids`, `allowed_fhir_user_types` and `required_roles` all write `''` — and `smart-client-enrichment.ts` reads anything that is not `'true'`/`'false'` back as `undefined`, so `''` lands exactly on the passthrough branch. No new convention.

The **response** schema keeps a plain boolean: the attribute is either present or absent, never null.

## Tests

Two added to `smart-apps-attributes.test.ts` — that null clears to `''`, and that a boolean still writes normally. The existing "every attribute is a string" invariant covers the rest, and `''` satisfies it.

Typecheck is unchanged: 25 pre-existing errors on clean `develop` and 25 with this change, none new.