### PR TITLE
fix(fhir-mcp): give the per-server MCP endpoint the FHIR proxy's audience policy

### DIFF
--- a/backend/src/lib/auth.ts
+++ b/backend/src/lib/auth.ts
@@ -28,8 +28,10 @@ export interface ValidateTokenOptions {
    * FHIR base as `aud`. The anti-leakage guarantee for FHIR is instead met by the
    * `aud`/`resource` REQUEST parameter validated at /authorize (issue #355
    * Phase 2), while issuer/signature/expiry verification and SMART scope
-   * enforcement remain the gates. This flag is a no-op for callers that omit it;
-   * admin and MCP call sites keep audience enforced.
+   * enforcement remain the gates. This flag is a no-op for callers that omit it.
+   * "The FHIR proxy" is the call site's job, not its path: the per-server FHIR MCP
+   * endpoint serves those same tools and shares the policy. The admin MCP endpoint,
+   * which administers the deployment rather than reading it, keeps audience enforced.
    */
   enforceAudience?: boolean
 }

--- a/backend/src/routes/fhir-mcp.ts
+++ b/backend/src/routes/fhir-mcp.ts
@@ -58,8 +58,11 @@ function handlerFor(serverId: string): McpHandler {
     cors: { origin: allowedOrigin },
     createServer: async (token) => {
       // Proven good before it is forwarded to FHIR as this request's identity.
+      // Audience unenforced, as on the FHIR proxy this wraps (#355): the same tools
+      // over the same server, so a stricter door here refuses only clients that can
+      // do the identical operations over REST with the identical token.
       try {
-        await validateToken(token ?? '')
+        await validateToken(token ?? '', { enforceAudience: false })
       } catch {
         throw new McpUnauthorizedError('Invalid or expired token')
       }

--- a/backend/test/fhir-mcp.test.ts
+++ b/backend/test/fhir-mcp.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, mock } from 'bun:test'
 
-const mockValidateToken = mock(async (token: string) => {
+const mockValidateToken = mock(async (token: string, _options?: { enforceAudience?: boolean }) => {
   if (token === 'bad-token') throw new Error('invalid')
   return { sub: 'test-user', iss: 'http://localhost:8080/realms/proxy-smart' }
 })
@@ -118,6 +118,16 @@ describe('FHIR MCP endpoint — Bearer gate', () => {
   it('returns 401 for a non-Bearer scheme', async () => {
     const res = await call(post(URL_ENABLED, { Authorization: 'Basic abc123' }))
     expect(res.status).toBe(401)
+  })
+
+  // Same tools over the same server as the FHIR proxy, so the same audience policy
+  // (#355). The default matcher set describes the ADMIN /mcp endpoint, and applying
+  // it here refused SMART tokens that REST accepts for the identical operations.
+  it('validates the token under the FHIR proxy audience policy', async () => {
+    mockValidateToken.mockClear()
+    await call(post(URL_ENABLED, { Authorization: 'Bearer good-token' }))
+    expect(mockValidateToken).toHaveBeenCalled()
+    expect(mockValidateToken.mock.calls[0]?.[1]).toMatchObject({ enforceAudience: false })
   })
 })
 


### PR DESCRIPTION
`/fhir/{server_id}/mcp` validated its bearer with no options, so enforcement fell through to the config-derived default set. That set describes the admin `/mcp` endpoint: the proxy's own client ids, the `{baseUrl}/mcp` resource URL, and the FHIR bases. A SMART client's token matches none of them — its `azp` is its own client id, and per SMART App Launch 2.2.0 its `aud` need not name the FHIR base at all.

So the MCP door was strictly stricter than the REST door beside it. The FHIR proxy already passes `enforceAudience: false` for exactly this reason (#355): the same token, against the same server, was accepted for a read over REST and refused for the identical read over MCP. To a client that refusal reads as "sign in" — against an authorization server that had already signed it in. Nothing was protected, since anything refused here could do the same operations over REST with the same token.

This is a FHIR call site that speaks MCP, which the file's own header already claimed ("Tools inherit all auth, consent, scope enforcement, and capability-aware normalization from the shared FHIR proxy infrastructure"). It now inherits the audience policy too. Issuer, signature and expiry are still verified; access stays gated by the `aud`/`resource` request parameter validated at `/authorize` and by SMART scope enforcement. The admin MCP endpoint is untouched and stays fail-closed.

## Changes

- `backend/src/routes/fhir-mcp.ts` — pass `enforceAudience: false`, matching the FHIR proxy.
- `backend/src/lib/auth.ts` — `ValidateTokenOptions` said "admin and MCP call sites keep audience enforced", which stopped being true of the FHIR MCP endpoint the moment it existed. Now states that the opt-out follows the call site's job, not its path.
- `backend/test/fhir-mcp.test.ts` — pins that the call site validates under the FHIR policy.

## Verification

- `bun run test` (backend): 1509 pass, 1 skip, 0 fail across 112 files.
- `bun run typecheck`: 0 errors.
- `bun run lint`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
