### PR TITLE
fix(auth): stop dropping prompt, nonce, login_hint and max_age at /authorize

### DIFF
--- a/backend/src/schemas/auth/oauth.ts
+++ b/backend/src/schemas/auth/oauth.ts
@@ -79,6 +79,10 @@ export type IntrospectResponseType = Static<typeof IntrospectResponse>
 
 // ==================== OAuth Query Parameters ====================
 
+/*
+ * An ALLOWLIST, not documentation: the interceptor forwards every param it receives, so
+ * anything undeclared here is dropped by validation before reaching it.
+ */
 export const AuthorizationQuery = t.Object({
   response_type: t.Optional(t.String({ description: 'OAuth response type' })),
   client_id: t.Optional(t.String({ description: 'OAuth client ID' })),
@@ -91,7 +95,11 @@ export const AuthorizationQuery = t.Object({
   resource: t.Optional(t.String({ description: 'RFC 8707 Resource Indicator — synonym for aud (servers MAY support)' })),
   launch: t.Optional(t.String({ description: 'EHR Launch: opaque launch context identifier received from the EHR (SMART App Launch 2.2.0)' })),
   authorization_details: t.Optional(t.String({ description: 'Authorization details JSON string for multiple FHIR servers' })),
-  kc_idp_hint: t.Optional(t.String({ description: 'Keycloak Identity Provider hint to skip provider selection' }))
+  kc_idp_hint: t.Optional(t.String({ description: 'Keycloak Identity Provider hint to skip provider selection' })),
+  prompt: t.Optional(t.String({ description: 'OIDC Core 3.1.2.1 — none, login, consent, select_account. `login` MUST re-authenticate instead of reusing the SSO session' })),
+  nonce: t.Optional(t.String({ description: 'OIDC Core 3.1.2.1 — bound into the id_token to detect replay' })),
+  login_hint: t.Optional(t.String({ description: 'OIDC Core 3.1.2.1 — identifier to prefill on the login form' })),
+  max_age: t.Optional(t.String({ description: 'OIDC Core 3.1.2.1 — seconds before the IdP must re-authenticate' })),
 }, { title: 'AuthorizationQuery' })
 export type AuthorizationQueryType = Static<typeof AuthorizationQuery>
 

--- a/backend/test/authorize-oidc-params.test.ts
+++ b/backend/test/authorize-oidc-params.test.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Max Health Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Commercial
+
+/**
+ * authorize-oidc-params.test.ts — standard OIDC authorize params survive validation.
+ *
+ * The interceptor forwards every param it is given, so the schema is the allowlist that
+ * decides what reaches the IdP at all. `prompt` was undeclared, so a client asking to
+ * re-authenticate was silently answered from the live SSO session instead — "use a different
+ * account" could not work behind this proxy, and no error said why.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { Value } from '@sinclair/typebox/value'
+import { AuthorizationQuery } from '../src/schemas/auth/oauth'
+
+/** What Elysia does to a query before a handler sees it: drop undeclared properties. */
+function validated(query: Record<string, string>): Record<string, unknown> {
+  return Value.Clean(AuthorizationQuery, { ...query }) as Record<string, unknown>
+}
+
+const BASE = {
+  response_type: 'code',
+  client_id: 'admin-console',
+  redirect_uri: 'https://app.example.com/callback',
+  scope: 'openid profile email',
+  state: 'abc',
+}
+
+describe('AuthorizationQuery keeps the OIDC params the interceptor forwards', () => {
+  test.each([
+    ['prompt', 'login'],
+    ['nonce', 'n-0S6_WzA2Mj'],
+    ['login_hint', 'someone@example.com'],
+    ['max_age', '0'],
+  ])('keeps %s', (param, value) => {
+    expect(validated({ ...BASE, [param]: value })[param]).toBe(value)
+  })
+
+  test('still drops a param nobody declared', () => {
+    // The allowlist is the point: widening it is a decision, not a side effect.
+    expect(validated({ ...BASE, made_up_param: 'x' }).made_up_param).toBeUndefined()
+  })
+
+  test('leaves the existing params alone', () => {
+    const out = validated({ ...BASE, aud: 'https://fhir.example.com/R4', launch: 'xyz' })
+    expect(out.aud).toBe('https://fhir.example.com/R4')
+    expect(out.launch).toBe('xyz')
+    expect(out.state).toBe('abc')
+  })
+})

--- a/config/eslint/package.json
+++ b/config/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/eslint-config",
-  "version": "0.4.4-beta.202608300013.82ab20e3a",
+  "version": "0.4.5-beta.202608300043.1ba9b4a6e",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/api-client",
-  "version": "0.4.4-beta.202608300013.82ab20e3a",
+  "version": "0.4.5-beta.202608300043.1ba9b4a6e",
   "private": false,
   "type": "module",
   "description": "Typed fetch client for the Proxy Smart admin and FHIR API, generated from its OpenAPI spec.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/cli",
-  "version": "0.4.4-beta.202608300013.82ab20e3a",
+  "version": "0.4.5-beta.202608300043.1ba9b4a6e",
   "private": false,
   "type": "module",
   "description": "Admin CLI for the proxy-smart SMART on FHIR authorization proxy. Authenticates via Keycloak OAuth (device flow or client_credentials) and drives the admin REST API.",

--- a/packages/patient-picker/package.json
+++ b/packages/patient-picker/package.json
@@ -3,7 +3,7 @@
   "displayName": "Proxy Smart Patient Picker",
   "description": "Patient selection UI shown during SMART standalone launch when patient context is needed.",
   "private": true,
-  "version": "0.4.4-beta.202608300013.82ab20e3a",
+  "version": "0.4.5-beta.202608300043.1ba9b4a6e",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5176",

--- a/testing/e2e/package.json
+++ b/testing/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proxy-smart/e2e",
-  "version": "0.4.4-beta.202608300013.82ab20e3a",
+  "version": "0.4.5-beta.202608300043.1ba9b4a6e",
   "private": true,
   "description": "End-to-end Playwright tests for Proxy Smart apps",
   "scripts": {


### PR DESCRIPTION
`authorize-interceptor` already forwards every query param it receives to the IdP, stripping only `aud`/`resource`. But `AuthorizationQuery` is a TypeBox object, so Elysia removes undeclared properties before the handler runs — and four standard [OIDC Core §3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) parameters were never declared. The schema is the allowlist; the forwarder never saw them.

## Why it matters

**`prompt`** is the one that bites. OIDC says `prompt=login` MUST re-authenticate rather than reuse the SSO session. Dropped silently, the opposite happens: authorize answers from the live session and returns the same account. Every app behind this proxy therefore has no working "use a different account" — the request is accepted, nothing errors, and the user loops through a sign-in that changes nothing. The only remaining mechanism is ending the session, which needs an `id_token_hint` the app no longer holds once it has cleared its tokens.

**`nonce`** is the quiet one. A client that sends it expects it echoed in the id_token to detect replay. The proxy dropped it, so the id_token came back without it, and a strict client is entitled to reject the response. Nothing logged that either.

`login_hint` and `max_age` are the same class of omission and are declared alongside them.

## Changes

- `backend/src/schemas/auth/oauth.ts` — declare `prompt`, `nonce`, `login_hint`, `max_age`, plus a note that this schema is an allowlist rather than documentation, since that is the part that was not obvious.
- `backend/test/authorize-oidc-params.test.ts` — pins that each survives validation, and that an undeclared param is still dropped, so widening the allowlist stays a deliberate act.

No new forwarding logic: the passthrough was already there.

## Verification

- `bun run test`: 1517 pass, 1 skip, 0 fail across 113 files.
- `bun run typecheck`: 0 errors. `bun run lint`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
