### PR TITLE
fix(mcp): describe the requested resource in path-scoped metadata, not the admin MCP

### DIFF
--- a/backend/src/routes/auth/mcp-metadata.ts
+++ b/backend/src/routes/auth/mcp-metadata.ts
@@ -67,12 +67,18 @@ export const mcpMetadataRoutes = new Elysia({ prefix: '/.well-known', tags: ['mc
 
   // Path-based resource metadata discovery (RFC 9728 §5.1)
   // Clients may request /.well-known/oauth-protected-resource{path} for path-scoped resources
-  .get('/oauth-protected-resource/*', () => {
+  .get('/oauth-protected-resource/*', ({ params }) => {
     const baseUrl = (config.baseUrl || 'http://localhost:3001').replace(/\/+$/, '')
-    const mcpPath = config.mcp?.path || '/mcp'
+    /*
+     * §3.1 inserts the well-known segment between host and resource path, so the wildcard IS
+     * the resource's path. This returned the admin MCP for every path instead, which a client
+     * validating `resource` against the endpoint it asked about must reject — so no per-server
+     * FHIR MCP endpoint could be authorized against at all.
+     */
+    const resourcePath = `/${params['*'] ?? ''}`.replace(/\/{2,}/g, '/')
 
     return {
-      resource: `${baseUrl}${mcpPath}`,
+      resource: `${baseUrl}${resourcePath}`,
       authorization_servers: [
         baseUrl
       ],

--- a/backend/test/mcp-metadata.test.ts
+++ b/backend/test/mcp-metadata.test.ts
@@ -147,6 +147,31 @@ describe('MCP Metadata — /.well-known/oauth-protected-resource/* (path-scoped)
     expect(body.resource).toBe(`${TEST_BASE_URL}${TEST_MCP_PATH}`)
     expect(body.authorization_servers).toBeInstanceOf(Array)
   })
+
+  it('describes the resource at the requested path, not the admin MCP', async () => {
+    // §3.1 inserts the well-known segment between host and resource path, so this document
+    // describes /fhir/hapi-fhir-server/mcp. Answering with the admin MCP made every
+    // per-server FHIR endpoint unauthorizable: a client checking `resource` against what it
+    // asked about sees a different URL and stops.
+    const app = createApp()
+    const res = await app.handle(
+      new Request('http://localhost/.well-known/oauth-protected-resource/fhir/hapi-fhir-server/mcp'),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.resource).toBe(`${TEST_BASE_URL}/fhir/hapi-fhir-server/mcp`)
+    // The AS is the proxy for every resource it fronts — that part was already right.
+    expect(body.authorization_servers[0]).toBe(TEST_BASE_URL)
+  })
+
+  it('never emits a double slash, whatever the client asked for', async () => {
+    const app = createApp()
+    const res = await app.handle(
+      new Request('http://localhost/.well-known/oauth-protected-resource//fhir//mcp'),
+    )
+    const body = await res.json()
+    expect((body.resource as string).replace(/^https?:\/\//, '')).not.toContain('//')
+  })
 })
 
 describe('MCP Metadata — /.well-known/oauth-authorization-server', () => {


### PR DESCRIPTION
The route named "path-scoped resource metadata discovery" ignores the path. Every request under `/.well-known/oauth-protected-resource/*` answers with `resource` = `${baseUrl}${config.mcp.path}`, so the document describing a per-server FHIR MCP endpoint claims to describe the admin MCP:

```
GET /.well-known/oauth-protected-resource/fhir/hapi-fhir-server/mcp
→ { "resource": "https://<host>/mcp", ... }
```

RFC 9728 §3.1 inserts the well-known segment between host and resource path, so the wildcard **is** the resource's path. A client that validates `resource` against the endpoint it asked about — which is the point of the field — sees a different URL and stops. No per-server FHIR MCP endpoint can be authorized against at all, and since those endpoints' 401 points straight at this document, the failure is reached by following the server's own advice.

## Changes

- `backend/src/routes/auth/mcp-metadata.ts` — derive `resource` from the wildcard. Repeated slashes are collapsed so the path-scoped document keeps the no-double-slash property the root one is already tested for.
- `backend/test/mcp-metadata.test.ts` — the existing case used `/oauth-protected-resource/mcp`, the one path where returning the admin MCP is indistinguishable from correct, which is why this went unseen. Now covers a per-server FHIR path, where it is not.

The root `/oauth-protected-resource` route is unchanged.

## Verification

- `bun run test`: 1519 pass, 1 skip, 0 fail across 113 files.
- `bun run typecheck`: 0 errors. `bun run lint`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
