### PR TITLE
chore(hooks): stamp package versions on release branches only

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,6 +20,19 @@ set -euo pipefail
 #                       every file; version.js now writes only real changes, so
 #                       there is nothing to clean up.
 
+# Only a RELEASE branch carries a stamped version: CI writes alpha on develop, beta on
+# test, RELEASE on main. Stamping anything else adds a commit to the very lines those
+# branches own, so a feature branch collects conflicts in manifests it never touched,
+# and it publishes nothing, so the stamp had no reader in the first place.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+case "$branch" in
+  develop|test|main) ;;
+  *)
+    echo "Skipping version sync: $branch is not a release branch"
+    exit 0
+    ;;
+esac
+
 echo "Syncing package versions before push..."
 
 # Ask what WOULD change before touching anything, so a refusal below leaves the


### PR DESCRIPTION
The pre-push hook syncs every `package.json` to the current version and commits the result, on whatever branch is being pushed. Only three branches have a version worth stamping: CI writes `alpha` on `develop`, `beta` on `test`, `RELEASE` on `main`.

A feature branch publishes nothing, so its stamp has no reader — and it lands on the very lines those three branches own. The branch then arrives at review with conflicts in manifests its author never opened, over a difference that carries no meaning: both sides are labels for the same commit.

That is exactly how it surfaced. #1149 changes two files under `backend/src` and reached its PR conflicting in five `package.json` files:

```
config/eslint/package.json          0.4.6-alpha.202608300801.10a843836   (branch)
                                    0.4.6-beta.202608300801.10a843836    (develop)
```

Same sha, same build number, different channel.

The hook's own header already names the mechanism:

> We deliberately do NOT auto-rebase here — rebasing causes version-string conflicts on every merge because CI stamps different alpha/beta versions on develop vs test.

This stops feeding that argument branches that were never part of it.

## What does not change

Release branches take the same path as before: same sync, same refusal to fold in an already-modified manifest, same commit message. CI is untouched — no workflow stamps a non-release branch, so nothing in the pipeline relied on this.

## Not addressed here

The release branches still conflict with each other by design, since each stamps a different channel into the same lines — that is what the recurring "absorb main branch (resolve version conflicts)" commits are. Fixing that means not carrying a generated version in the tree at all, which is a larger change: `config.version` is read at runtime by the MCP server info, the OpenAPI document, system status, and `buildSourceOffer`, where the embedded commit sha is what points an AGPL recipient at the corresponding source. Worth doing deliberately, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
