### PR TITLE
feat(build): let the builder supply the commit, and fix a source offer that could point nowhere

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -156,6 +156,7 @@ jobs:
           build-args: |
             VITE_ENCRYPTION_SECRET=${{ secrets.VITE_ENCRYPTION_SECRET }}
             DEPLOY_ENV=beta
+            BUILD_SHA=${{ github.sha }}
           # No GITHUB_TOKEN fallback: @max-network is another org and refuses it, so
           # falling back only trades a clear error for an 18-minute stall.
           secrets: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -145,6 +145,7 @@ jobs:
           build-args: |
             VITE_ENCRYPTION_SECRET=${{ secrets.VITE_ENCRYPTION_SECRET }}
             DEPLOY_ENV=prod
+            BUILD_SHA=${{ github.sha }}
           # No GITHUB_TOKEN fallback: @max-network is another org and refuses it, so
           # falling back only trades a clear error for an 18-minute stall.
           secrets: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,11 @@ RUN bun run docs:build
 FROM base AS backend
 WORKDIR /app
 
+# The commit this image was built from, so the running server can name its own source for
+# the AGPL offer without the repository carrying a stamped version.
+ARG BUILD_SHA=""
+ENV BUILD_SHA=$BUILD_SHA
+
 # Install minimal runtime dependencies (Java 21 needed for @opendataloader/pdf)
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -40,6 +40,20 @@ try {
 }
 
 /**
+ * The commit this build was made from, supplied by the builder rather than the repository.
+ *
+ * Lets the deployed version name its own source without the tree carrying a stamped
+ * version — which is what makes develop, test and main rewrite the same manifest lines and
+ * conflict. Absent (a local run), the version is the base one and nothing changes.
+ */
+function versionWithBuildSha(base: string): string {
+  const sha = (process.env.BUILD_SHA || process.env.GITHUB_SHA || '').trim().toLowerCase()
+  if (!/^[0-9a-f]{7,40}$/.test(sha)) return base
+  // A version the release automation already stamped carries the commit; do not say it twice.
+  return base.includes(sha) ? base : `${base}+${sha}`
+}
+
+/**
  * Application configuration from environment variables
  */
 export const config = {
@@ -68,7 +82,7 @@ export const config = {
   // Application name and version from package.json
   name: packageJson.name,
   displayName: packageJson.displayName || packageJson.name,
-  version: packageJson.version,
+  version: versionWithBuildSha(packageJson.version),
   
   keycloak: {
     // Dynamic getters that read from process.env for real-time updates

--- a/backend/src/lib/source-offer.ts
+++ b/backend/src/lib/source-offer.ts
@@ -28,10 +28,27 @@ export interface SourceOffer {
   }
 }
 
-/** Extract the trailing git SHA embedded by the release automation, if present. */
+/**
+ * The git SHA a version names, if it names one.
+ *
+ * Two shapes: SemVer build metadata (`0.4.6+10a84383`), which a build stamps without the
+ * repository carrying it, and the trailing dot-segment the release automation has emitted
+ * so far (`0.2.13-beta.202607241442.ef7430c8b`). Both are read so a deployment running
+ * either keeps answering the AGPL offer with its exact commit.
+ */
 export function commitFromVersion(version: string): string | null {
-  const last = version.split('.').pop() ?? ''
-  return /^[0-9a-f]{7,40}$/i.test(last) ? last : null
+  const isSha = (value: string) => /^[0-9a-f]{7,40}$/i.test(value)
+
+  const build = version.split('+')[1]
+  if (build && isSha(build)) return build
+
+  // Legacy shape is `<base>-<channel>.<build>.<sha>`, so the commit is the last of at least
+  // three segments. A lone trailing segment is the build number — all digits, therefore
+  // valid hex — which read as a commit and offered a tree that does not exist.
+  const prerelease = version.split('-').slice(1).join('-')
+  const parts = prerelease.split('.')
+  const last = parts[parts.length - 1] ?? ''
+  return parts.length >= 3 && isSha(last) ? last : null
 }
 
 function stripTrailingSlash(url: string): string {

--- a/backend/test/source-offer-commit.test.ts
+++ b/backend/test/source-offer-commit.test.ts
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Max Health Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Commercial
+
+/**
+ * source-offer-commit.test.ts — the AGPL offer names the exact commit, on either version shape.
+ *
+ * The version has carried the commit as a trailing dot-segment written into every
+ * package.json by the release automation. That stamp is what makes develop, test and main
+ * rewrite the same lines and conflict, so a build may instead supply the commit itself and
+ * leave the tree holding a plain base version. Section 13 does not care which, as long as a
+ * network user can still reach the source for the version they are talking to.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { commitFromVersion } from '../src/lib/source-offer'
+
+const SHA = '10a843836'
+
+describe('commitFromVersion', () => {
+  test('reads the commit a build supplied as SemVer build metadata', () => {
+    expect(commitFromVersion(`0.4.6+${SHA}`)).toBe(SHA)
+  })
+
+  test('still reads the commit the release automation stamps', () => {
+    // Deployments running the old shape must keep answering, so this is not replaced.
+    expect(commitFromVersion(`0.2.13-beta.202607241442.${SHA}`)).toBe(SHA)
+  })
+
+  test('agrees on the commit whichever way it was carried', () => {
+    expect(commitFromVersion(`0.4.6+${SHA}`)).toBe(commitFromVersion(`0.4.6-beta.202608300801.${SHA}`))
+  })
+
+  test('answers null rather than guessing when no commit is named', () => {
+    // A plain semver build has no commit to offer; buildSourceOffer falls back to the tag.
+    expect(commitFromVersion('0.4.6')).toBeNull()
+    expect(commitFromVersion('0.4.6-beta.202608300801')).toBeNull()
+    expect(commitFromVersion('0.0.1-alpha')).toBeNull()
+  })
+
+  test('refuses build metadata that is not a commit', () => {
+    expect(commitFromVersion('0.4.6+dirty')).toBeNull()
+    expect(commitFromVersion('0.4.6+2026-08-30')).toBeNull()
+  })
+
+  test('accepts a full-length sha as well as a short one', () => {
+    const full = 'a'.repeat(40)
+    expect(commitFromVersion(`0.4.6+${full}`)).toBe(full)
+  })
+})


### PR DESCRIPTION
The deployed version has to name the commit it was built from: AGPL §13 means a network user must be able to fetch the source for the version they are talking to, and `buildSourceOffer` reads that commit out of the version string.

Today the only way it gets there is the release automation writing a stamped version into every `package.json` and committing it. That stamp is also what makes `develop`, `test` and `main` rewrite the same manifest lines and conflict — the recurring "absorb main branch (resolve version conflicts)" commits.

**The commit can come from the builder instead.** `BUILD_SHA` (or `GITHUB_SHA`) is read at startup and appended as SemVer build metadata, so an image knows its own commit whether or not the tree carries a stamp. Same approach as `fontlogo-mcp/scripts/inject-version.cjs`, which stamps `${base}+${sha}` at build rather than committing it.

Verified against a real build:

```
BUILD_SHA=ca91361b5
config.version : 0.4.6-beta.202608300801.10a843836+ca91361b5
commit         : ca91361b5
sourceUrl      : https://github.com/proxy-smart/proxy-smart/tree/ca91361b5
```

and in the target state, where the tree holds only a base version:

```
0.4.6+ca91361b5  ->  ca91361b5
0.4.6            ->  null        (falls back to the release tag, as before)
```

## This does not stop the stamping

It removes the reason the stamp has to exist. Both shapes are read, so a deployment already running the old one keeps answering with its exact commit, and this can merge without touching the release workflows. Dropping the stamp is the follow-up, and it is what ends the branch conflicts.

## Also fixes a latent hole

`commitFromVersion` took the last dot-segment and accepted anything matching `/^[0-9a-f]{7,40}$/`. A build number is all digits — which is valid hex. So a version ending in its build number rather than a sha resolved to **the build number as the commit**, and the AGPL offer linked to `/tree/202608300801`, a tree that does not exist. The legacy shape is `<base>-<channel>.<build>.<sha>`, so the commit is now read only as the last of at least three prerelease segments.

Found by the new test, not by inspection.

## Verification

- `bun run test`: 1525 pass, 1 skip, 0 fail across 114 files.
- `bun run typecheck`: 0 errors. `bun run lint`: 0 errors.
- Local run with `BUILD_SHA` set, asserting the resolved `sourceUrl` (above).

Not verified by me: the image build and deploy jobs, which I cannot execute. The Dockerfile change is one `ARG`/`ENV` pair in the `backend` stage and one line in each deploy workflow's existing `build-args` block, defaulting to empty — with `BUILD_SHA` unset the behaviour is exactly today's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
