### PR TITLE
feat(publish): take the release version from the tag, not from a committed manifest

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -40,6 +40,9 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Tags are the release identity below; a shallow checkout has none.
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-bun-version
 
@@ -66,10 +69,37 @@ jobs:
           cd backend && bun run export-openapi && cd ..
           bun run generate:clients
 
+      # The release version, from the tag on this commit rather than from a manifest.
+      #
+      # The tag is created by the release, so it names the release; the version in
+      # package.json is only there because the automation commits it back, which is what
+      # makes develop, test and main rewrite the same lines and conflict. While it is still
+      # committed the two agree and this changes nothing — it is what lets the commit stop.
+      #
+      # Falls back to the manifest when no tag points here, so a manual run still publishes
+      # what a checkout says it is.
+      - name: Resolve release version
+        id: release
+        run: |
+          set -euo pipefail
+          # A commit can in principle carry more than one channel's tag, and this job only
+          # ever runs on main, so a RELEASE tag wins over any prerelease one that reached it.
+          TAGS=$(git tag --points-at HEAD --sort=-creatordate | grep -E '^v[0-9]' || true)
+          TAG=$(grep -- '-RELEASE\.' <<< "$TAGS" | head -1 || true)
+          [ -n "$TAG" ] || TAG=$(head -1 <<< "$TAGS")
+          if [ -n "$TAG" ]; then
+            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+            echo "Release version ${TAG#v} (from tag $TAG)"
+          else
+            echo "version=" >> "$GITHUB_OUTPUT"
+            echo "No release tag on this commit - using each manifest's own version"
+          fi
+
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
           OWNER_SCOPE: '@${{ github.repository_owner }}'
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
           OWNER_SCOPE=$(echo "$OWNER_SCOPE" | tr '[:upper:]' '[:lower:]')
@@ -81,7 +111,7 @@ jobs:
             [ "$PRIVATE" = "false" ] || continue
 
             NAME=$(node -p "require('./${dir}package.json').name")
-            VERSION=$(node -p "require('./${dir}package.json').version")
+            VERSION="${RELEASE_VERSION:-$(node -p "require('./${dir}package.json').version")}"
             SCOPE="${NAME%%/*}"
 
             if [ "$SCOPE" != "$OWNER_SCOPE" ]; then
@@ -99,8 +129,10 @@ jobs:
               continue
             fi
 
+            # npm publishes what the manifest says, so the resolved version has to be in it.
+            # Written in the runner only and never committed — that is the whole point.
             echo "Publishing $NAME@$VERSION"
-            (cd "$dir" && npm publish)
+            (cd "$dir" && npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null && npm publish)
             echo "- \`$NAME@$VERSION\` published." >> "$GITHUB_STEP_SUMMARY"
             PUBLISHED=$((PUBLISHED+1))
           done


### PR DESCRIPTION
`publish-packages.yml` states its own contract in its header:

> **RELEASING = THE VERSION IN package.json.** A run whose version is already on the registry publishes nothing and says so.

That is *why* the release automation writes a stamped version into every manifest and commits it back — and that commit is what makes `develop`, `test` and `main` rewrite the same lines and conflict with each other (the recurring "absorb main branch (resolve version conflicts)" commits).

**The tag already names the release.** It is created by the release, carries the same version, and unlike the manifest it does not have to be written into the tree to be true. So the version now comes from the tag on the commit being published, falling back to the manifest when no tag points there — which keeps a manual `workflow_dispatch` publishing what a checkout says it is.

While the stamp is still committed the two agree and **nothing changes**. That is the point: this is what lets the commit stop, without the publish path being the thing that breaks when it does. Same staging as #1153, which did the equivalent for the runtime's commit identity.

## Three details

**npm publishes what the manifest says.** The resolved version is written with `npm version --no-git-tag-version --allow-same-version` in the runner and never committed.

**The trigger is unchanged** (`push: branches: [main]`). Tags exist for alpha and beta too —

```
v0.4.6-alpha.202608300852.15afb1696
v0.4.6-beta.202608300840.a2036590b
```

— so firing on `push: tags: [v*]` would start publishing prerelease CLI and api-client builds from every develop push. That would be a silent scope change with registry consequences.

**A RELEASE tag wins.** A commit can in principle carry more than one channel's tag, and this only runs on `main`, so `-RELEASE.` is preferred over any prerelease tag that reached it. No commit carries two `v` tags today; this is so it stays true.

`fetch-depth: 0` is added because tags are the release identity here and a shallow checkout has none.

## Verification

- YAML parses; step order unchanged apart from the new resolve step.
- Tag selection exercised against the repository's real tags: a tagged commit resolves `0.4.6-beta.202608300840.a2036590b`; an untagged commit resolves empty and falls back; a commit with both a beta and a RELEASE tag resolves the RELEASE one.

Not verified by me: an actual publish run, which I cannot execute. With the stamp still being committed, the tag and the manifest agree, so the first run after merge should be a no-op that publishes nothing — that is the safe way to confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
