### PR TITLE
fix(theme): make the two page-expired links say what they do, and backfill client baseUrl

### DIFF
--- a/backend/src/lib/kc-system-provisioning.ts
+++ b/backend/src/lib/kc-system-provisioning.ts
@@ -18,6 +18,7 @@ import { logger } from './logger'
 import { RESOURCE_INDICATORS_SCOPE } from './smart-client-enrichment'
 import { ensureMappersOnScope } from './smart-scope-mappers'
 import { getFhirResourceUrls } from './fhir-server-store'
+import { resolveClientHomeUrl } from '@proxy-smart/auth'
 
 /** Keycloak client attribute: let this client introspect tokens it isn't in the aud of. */
 const ALLOW_INTROSPECTION_WITHOUT_AUDIENCE = 'allow.token.introspection.without.audience.check'
@@ -354,6 +355,43 @@ async function attachResourceIndicatorsToExistingClients(
  * Returns the resulting resource clients for confirmation. Idempotent; each step
  * is individually non-fatal.
  */
+/**
+ * Backfill `baseUrl` on SMART clients that predate it being set at registration.
+ *
+ * Keycloak renders "Back to Application" on its error and page-expired screens
+ * from the client's baseUrl. Clients registered before resolveClientHomeUrl was
+ * wired in have none, so every failed login on them offered a link to the theme's
+ * PROXY_PUBLIC_URL — this proxy's API host — instead of the app the launch came
+ * from. New clients get it at registration; this fixes the ones already there.
+ *
+ * Only fills a blank. An operator who set a baseUrl by hand in the Keycloak admin
+ * console meant it, and a redirect URI is a worse source of truth than that.
+ */
+export async function reconcileClientHomeUrls(
+  admin: KcAdminClient,
+): Promise<{ clientId: string; baseUrl: string }[]> {
+  const clients = await admin.clients.find()
+  const updated: { clientId: string; baseUrl: string }[] = []
+
+  for (const client of clients) {
+    if (!client.id || !client.clientId) continue
+    if (client.attributes?.['smart_app'] !== 'true') continue
+    if (client.baseUrl && client.baseUrl.trim() !== '') continue
+
+    const baseUrl = resolveClientHomeUrl({
+      redirectUris: client.redirectUris,
+      proxyBaseUrl: config.baseUrl,
+    })
+    if (!baseUrl) continue
+
+    await admin.clients.update({ id: client.id }, { baseUrl } as ClientRepresentation)
+    updated.push({ clientId: client.clientId, baseUrl })
+    logger.admin.info('Backfilled client baseUrl', { clientId: client.clientId, baseUrl })
+  }
+
+  return updated
+}
+
 export async function reconcileResourceIndicators(
   admin: KcAdminClient,
 ): Promise<{ clientId: string; resourceUrl?: string }[]> {

--- a/backend/src/routes/admin/smart-config.ts
+++ b/backend/src/routes/admin/smart-config.ts
@@ -9,7 +9,7 @@ import { extractBearerToken } from '@/lib/admin-utils'
 import { handleAdminError } from '@/lib/admin-error-handler'
 import { CommonErrorResponses, SmartConfigRefreshResponse, type SmartConfigurationResponseType } from '@/schemas'
 import { getAdminClient } from '@/lib/kc-admin-factory'
-import { reconcileResourceIndicators } from '@/lib/kc-system-provisioning'
+import { reconcileClientHomeUrls, reconcileResourceIndicators } from '@/lib/kc-system-provisioning'
 
 /**
  * SMART Configuration Admin endpoints
@@ -91,6 +91,51 @@ export const smartConfigAdminRoutes = new Elysia({ prefix: '/smart-config', tags
     detail: {
       summary: 'Reconcile RFC 8707 resource indicators',
       description: 'Create/repair the resource-server clients (fhir-resource-server, mcp-resource-server), the resource-indicators client scope and its audience mappers, so SMART token exchange can bind the FHIR/MCP resource aud. Fixes invalid_target on a realm that was imported with IGNORE_EXISTING. Idempotent.',
+      tags: ['admin', 'smart-apps'],
+      security: [{ BearerAuth: [] }],
+    },
+  })
+
+  .post('/reconcile-client-home-urls', async ({ set, headers }) => {
+    const auth = extractBearerToken(headers)
+    if (!auth) {
+      set.status = 401
+      return { error: 'Authentication required' }
+    }
+
+    try {
+      await validateToken(auth)
+
+      const admin = await getAdminClient()
+      if (!admin) {
+        set.status = 503
+        return { error: 'Keycloak admin client unavailable' }
+      }
+
+      const clients = await reconcileClientHomeUrls(admin)
+      return {
+        message: `Backfilled baseUrl on ${clients.length} client(s)`,
+        timestamp: new Date().toISOString(),
+        clients,
+      }
+    } catch (error) {
+      return handleAdminError(error, set)
+    }
+  }, {
+    response: {
+      200: t.Object({
+        message: t.String(),
+        timestamp: t.String(),
+        clients: t.Array(t.Object({
+          clientId: t.String(),
+          baseUrl: t.String(),
+        })),
+      }),
+      ...CommonErrorResponses,
+    },
+    detail: {
+      summary: 'Backfill client home URLs',
+      description: "Set baseUrl from the redirect URIs on SMART clients that have none, so Keycloak's error and page-expired screens link back to the app rather than to this proxy's API host. Clients registered before this was wired in have no baseUrl; new ones get it at registration. Never overwrites a baseUrl that is already set. Idempotent.",
       tags: ['admin', 'smart-apps'],
       security: [{ BearerAuth: [] }],
     },

--- a/keycloak/themes/proxy-smart/login/login-page-expired.ftl
+++ b/keycloak/themes/proxy-smart/login/login-page-expired.ftl
@@ -1,0 +1,27 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout; section>
+    <#if section = "header">
+        ${msg("pageExpiredTitle")}
+    <#elseif section = "form">
+        <#--
+            The base template renders both actions as the word "Click here", so the
+            two links are indistinguishable at a glance even though they do very
+            different things — one resumes the login in progress, the other throws it
+            away and starts over. Label each link with its own verb instead, and put
+            continuing first because that is what someone who just hit the back button
+            actually wants.
+
+            doContinue and restartLoginTooltip are existing Keycloak message keys, so
+            both labels stay translated in every locale the realm offers. A theme
+            messages file would only have covered English.
+        -->
+        <p id="instruction-continue" class="instruction">
+            ${msg("pageExpiredMsg2")}:
+            <a id="loginContinueLink" href="${url.loginAction}">${msg("doContinue")}</a>
+        </p>
+        <p id="instruction-restart" class="instruction">
+            ${msg("pageExpiredMsg1")}:
+            <a id="loginRestartLink" href="${url.loginRestartFlowUrl}">${msg("restartLoginTooltip")}</a>
+        </p>
+    </#if>
+</@layout.registrationLayout>


### PR DESCRIPTION
Two bad-UX reports on the Keycloak error screens.

## 1. `Page has expired` — two links, both reading "Click here"

Keycloak's base `login-page-expired.ftl` renders both actions as the word "Click here". The sentences above them differ, but the *links* are identical, so the page offers a choice it never explains — and the two are not equivalent: one resumes the login in progress, the other discards it and starts over.

Each link now carries its own verb, and continuing comes first because that's what someone who just hit the back button wants:

```
To continue the login process: Continue
To restart the login process: Restart login
```

`doContinue` and `restartLoginTooltip` are existing Keycloak message keys (verified against 26.6.4), so both labels stay translated in every locale the realm offers. A theme `messages_en.properties` would have covered English only and silently regressed the rest.

## 2. `Back to Application` pointing at the API host

It's rendered from the client's `baseUrl`. `resolveClientHomeUrl` already sets that at registration and is on `main` — but nothing repaired clients registered *before* it, so those still fall through to the theme's `PROXY_PUBLIC_URL`, which in production is `api.proxy-smart.com`. That's why the button still misbehaves there.

`reconcileClientHomeUrls` backfills `baseUrl` from the redirect URIs on SMART clients that have none. It fills only a blank — an operator who set one by hand meant it, and a redirect URI is a worse source of truth. Exposed as `POST /admin/smart-config/reconcile-client-home-urls` rather than folded into `reconcile-resource-indicators`, whose response shape is part of the generated client.

**Note:** the backfill is a manual call, matching the existing reconcile. It won't fix production until someone invokes it.

Backend typechecks, lint clean, 1549 tests pass.