### PR TITLE
fix(seo): give the named crawler groups the full disallow list

### DIFF
--- a/backend/public/robots.txt
+++ b/backend/public/robots.txt
@@ -9,46 +9,34 @@ Disallow: /auth
 Disallow: /mcp
 Disallow: /webapp
 
-# AI Crawlers — Welcome
+# AI crawlers — welcome on the public pages.
+#
+# One group for all of them, carrying the SAME disallow list as the wildcard above.
+# robots.txt has no inheritance: a named User-agent group REPLACES the `*` group rather
+# than extending it. These groups each named /admin, /fhir and /auth but omitted /mcp and
+# /webapp, so every crawler listed here was told those two were fair game while `*` was not.
+# Repeating the list once, rather than per crawler, is also why it can no longer drift.
+#
+# The set is the org's: GPTBot trains, OAI-SearchBot indexes for ChatGPT search and
+# ChatGPT-User fetches on a user's behalf — only the first was named here, so the two that
+# actually drive a citation were left to the wildcard. Same for the current Claude pair.
 User-agent: GPTBot
-Allow: /
-Allow: /llms.txt
-Allow: /docs
-Disallow: /admin
-Disallow: /fhir
-Disallow: /auth
-
+User-agent: OAI-SearchBot
+User-agent: ChatGPT-User
 User-agent: ClaudeBot
-Allow: /
-Allow: /llms.txt
-Allow: /docs
-Disallow: /admin
-Disallow: /fhir
-Disallow: /auth
-
+User-agent: Claude-SearchBot
+User-agent: Claude-User
+User-agent: PerplexityBot
+User-agent: Perplexity-User
 User-agent: Google-Extended
-Allow: /
-Allow: /llms.txt
-Allow: /docs
-Disallow: /admin
-Disallow: /fhir
-Disallow: /auth
-
+User-agent: Applebot-Extended
 User-agent: Bingbot
 Allow: /
-Allow: /llms.txt
-Allow: /docs
 Disallow: /admin
 Disallow: /fhir
 Disallow: /auth
-
-User-agent: PerplexityBot
-Allow: /
-Allow: /llms.txt
-Allow: /docs
-Disallow: /admin
-Disallow: /fhir
-Disallow: /auth
+Disallow: /mcp
+Disallow: /webapp
 
 # Sitemap
 Sitemap: https://proxy-smart.com/sitemap.xml

--- a/backend/public/sitemap.xml
+++ b/backend/public/sitemap.xml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- No changefreq or priority: Google has ignored both since 2023. No lastmod either, since
+     these pages have no recorded modification date and an invented one is worse than none. -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://proxy-smart.com/</loc>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://proxy-smart.com/docs</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://proxy-smart.com/apps</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
   </url>
 </urlset>


### PR DESCRIPTION
robots.txt has no inheritance: a named `User-agent` group **replaces** the `*` group rather than extending it.

The five named AI-crawler groups each carried `Disallow` for `/admin`, `/fhir` and `/auth` but omitted `/mcp` and `/webapp`, both of which the wildcard group disallows. GPTBot, ClaudeBot, Google-Extended, Bingbot and PerplexityBot were therefore each told those two paths were fair game, while every other crawler was kept out.

The list is now written once for one combined group instead of five times, so it cannot drift out of step again — which is how the two came to be missing.

The named set also gains the tokens that actually drive citations. `GPTBot` trains, but `OAI-SearchBot` indexes for ChatGPT search and `ChatGPT-User` fetches on a user's behalf, and only `GPTBot` was named; same for `Claude-SearchBot` / `Claude-User` against `ClaudeBot`. Added along with `Perplexity-User` and `Applebot-Extended`, matching the set the rest of the org names.

`sitemap.xml` drops `changefreq` and `priority`, ignored by Google since 2023. No `lastmod` added: these pages have no recorded modification date and an invented one is worse than none.

Static files rather than generated, unlike the other sites in this sweep: `@max-network/seo` is a private package in a different org, so consuming it here would mean cross-org registry credentials in CI for what is a three-URL sitemap.