### PR TITLE
fix(ci): resolve the registry token in the publish workflows

### DIFF
--- a/.github/scripts/npm-registry-version.sh
+++ b/.github/scripts/npm-registry-version.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Max Health Inc.
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Commercial
+
+# Prints a version from the registry, or nothing if absent. Fails only when the
+# registry could not be read, so a caller cannot mistake that for "unpublished".
+#
+# Usage: npm-registry-version.sh <name>[@<version>]
+
+set -euo pipefail
+
+SPEC="${1:?usage: npm-registry-version.sh <name>[@<version>]}"
+REGISTRY="${NPM_REGISTRY:-https://npm.pkg.github.com}"
+
+ERR="$(mktemp)"
+trap 'rm -f "$ERR"' EXIT
+
+FOUND="$(npm view "$SPEC" version --registry="$REGISTRY" 2>"$ERR" || true)"
+
+if [ -z "$FOUND" ] && grep -qE 'E401|E403|ENEEDAUTH|EAUTHUNKNOWN' "$ERR"; then
+  echo "::error::Cannot read $SPEC from $REGISTRY - the token is not authenticating. Refusing to treat that as unpublished." >&2
+  sed 's/^/  /' "$ERR" >&2
+  exit 1
+fi
+
+printf '%s\n' "$FOUND" | tail -1

--- a/.github/workflows/publish-ig.yml
+++ b/.github/workflows/publish-ig.yml
@@ -72,10 +72,12 @@ jobs:
           echo "BABELFHIR_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "babelfhir-ts: $VERSION"
 
+      # Reads below resolve ./.npmrc's ${GH_PACKAGES_TOKEN}.
       - name: Decide whether to publish (build key vs last published)
         id: decide
         env:
           NODE_AUTH_TOKEN: ${{ github.token }}
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
         run: |
           # Identity = FSH source content + generator version + flags (deterministic;
           # generated output bakes per-run timestamps so can't be hashed directly).
@@ -91,7 +93,7 @@ jobs:
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
           echo "build key: $KEY"
 
-          LATEST=$(npm view "$PKG_NAME" version 2>/dev/null || true)
+          LATEST=$(.github/scripts/npm-registry-version.sh "$PKG_NAME")
           if [ -z "$LATEST" ]; then
             echo "First publish of $PKG_NAME at IG version $BASE"
             echo "publish=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -101,9 +101,11 @@ jobs:
       # is unforgiving about how one is provisioned, and a credential that cannot be read back
       # is a bad thing to depend on for a release. It stays where it is genuinely needed: the
       # install step, which reads packages from OTHER repositories that `github.token` cannot.
+      # Reads resolve ./.npmrc's ${GH_PACKAGES_TOKEN}; writes stay on NODE_AUTH_TOKEN.
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ github.token }}
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
           OWNER_SCOPE: '@${{ github.repository_owner }}'
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
@@ -126,16 +128,7 @@ jobs:
               continue
             fi
 
-            # `npm view` exits non-zero for an unpublished version — that is the
-            # success path here, so swallow it and test the captured output. But ONLY that:
-            # an auth failure is also non-zero and also empty, and swallowing it too turned
-            # "I cannot see the registry" into "not published yet, go ahead and publish".
-            VIEW_ERR=$(mktemp)
-            FOUND=$(npm view "$NAME@$VERSION" version --registry=https://npm.pkg.github.com 2>"$VIEW_ERR" || true)
-            if [ -z "$FOUND" ] && grep -qE 'E401|ENEEDAUTH|EAUTHUNKNOWN' "$VIEW_ERR"; then
-              echo "::error::Cannot read $NAME from the registry — the token is not authenticating. Refusing to treat that as unpublished."
-              exit 1
-            fi
+            FOUND=$(.github/scripts/npm-registry-version.sh "$NAME@$VERSION")
             if [ -n "$FOUND" ]; then
               echo "- \`$NAME@$VERSION\` already published." >> "$GITHUB_STEP_SUMMARY"
               SKIPPED=$((SKIPPED+1))


### PR DESCRIPTION
Both `Publish packages` and `Publish FHIR IG package` have failed on every run since 2026-08-30, most recently on the `#1173` merge commit `73e24f5`.

## Cause

Both read the registry from the repository root, where `./.npmrc` sets `//npm.pkg.github.com/:_authToken=${GH_PACKAGES_TOKEN}`. A project `.npmrc` outranks the one `setup-node` writes, and neither step set that variable, so it expanded to an empty string and every read returned 401.

The two workflows then diverged on what they did with that:

- **Publish packages** failed the run with `Cannot read @proxy-smart/api-client from the registry`, which is exactly what its guard exists to do.
- **Publish FHIR IG** swallowed it with `2>/dev/null || true`, read the empty result as "nothing published yet", and tried to publish `@proxy-smart/consent-fhir@0.1.0` over itself, giving `E409 Cannot publish over existing version`.

## Change

Both reading steps now set `GH_PACKAGES_TOKEN`. Writes are unaffected, since `npm publish` runs in `packages/<name>/` and `dist-ig/`, neither of which has an `.npmrc`, so it keeps using `NODE_AUTH_TOKEN`.

The check that separates "unpublished" from "cannot read the registry" moved to `.github/scripts/npm-registry-version.sh`, called by both workflows instead of one having it and the other silently not. `E403` joins the patterns it counts as an auth failure.

## Verification

Against the live registry: prints `0.1.0` for `consent-fhir` with a token, prints nothing and exits 0 for a version that does not exist, and exits non-zero with no token. Both workflow files parse, and the script passes `bash -n`.

Both workflows trigger on push to `main`, so this is only exercised once it lands there.