### PR TITLE
fix: report last login correctly, and declare the membership attributes the IdP imports

### DIFF
--- a/backend/src/init/realm-settings.ts
+++ b/backend/src/init/realm-settings.ts
@@ -191,6 +191,12 @@ const REQUIRED_USER_ATTRIBUTES = [
   { name: 'fhir_persons', displayName: 'FHIR Person Associations', permissions: { view: ['admin'], edit: ['admin'] }, multivalued: false },
   { name: 'organization', displayName: 'Organization', permissions: { view: ['admin', 'user'], edit: ['admin'] }, multivalued: false },
   { name: 'lastLogin', displayName: 'Last Login', permissions: { view: ['admin'], edit: ['admin'] }, multivalued: false },
+  // Imported from the Max Health IdP. Undeclared, the importer's write was dropped here in
+  // silence: the mapper existed and reported healthy, the claim was always sent, and the
+  // attribute simply never appeared — so every brokered user read as the `free` tier.
+  { name: 'membership_tier', displayName: 'Max Health Membership Tier', permissions: { view: ['admin', 'user'], edit: ['admin'] }, multivalued: false },
+  { name: 'early_access', displayName: 'Early Access', permissions: { view: ['admin', 'user'], edit: ['admin'] }, multivalued: false },
+  { name: 'premium_support', displayName: 'Premium Support', permissions: { view: ['admin', 'user'], edit: ['admin'] }, multivalued: false },
 ]
 
 interface UserProfile {

--- a/backend/src/lib/last-login.ts
+++ b/backend/src/lib/last-login.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Max Health Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Commercial
+
+/**
+ * Record when a user last logged in.
+ *
+ * Keycloak stores no last-login on the user: the only first-class record is a LOGIN event,
+ * and events are off by default (and retaining per-user access logs on a health IdP is a
+ * retention decision, not a code one). So it is kept as a user attribute — `lastLogin` is
+ * already declared on the realm's user profile for exactly this, which matters because
+ * Keycloak 26 silently drops attributes the profile does not declare.
+ *
+ * Written on the authorization_code grant only. A refresh is not a login, and writing there
+ * would move the value every time a token aged out rather than when the person actually
+ * signed in.
+ */
+
+import { getAdminClient } from './kc-admin-factory'
+import { setUserAttribute } from './admin-utils'
+import { logger } from './logger'
+
+/**
+ * Stamp `lastLogin` on a user, best-effort.
+ *
+ * Never throws and is not awaited by the token endpoint: a failure here must not fail, or
+ * delay, a sign-in that Keycloak has already granted.
+ */
+export async function recordLastLogin(userId: string): Promise<void> {
+  try {
+    const admin = await getAdminClient()
+    if (!admin) return
+    await setUserAttribute(admin, userId, 'lastLogin', String(Date.now()))
+  } catch (error) {
+    logger.auth.warn('Could not record last login', { userId, error })
+  }
+}

--- a/backend/src/routes/admin/healthcare-users.ts
+++ b/backend/src/routes/admin/healthcare-users.ts
@@ -99,24 +99,18 @@ export const healthcareUsersRoutes = new Elysia({ prefix: '/healthcare-users' })
         })
       )
       
+      // Same client for every user in the loop below, so it is looked up once.
+      const adminUiClientId = await admin.clients
+        .find({ clientId: 'admin-ui' })
+        .then(clients => clients[0]?.id)
+        .catch(error => {
+          logger.admin.warn('Could not resolve the admin-ui client', { error })
+          return undefined
+        })
+
       // Filter for healthcare users and map them with role information
       const healthcareUsers = await Promise.all(completeUsers.map(async (user) => {
         const profile = mapHealthcareUser(user)
-        
-        // Try to get user sessions for last login info
-        let lastLogin: number | null = null
-        try {
-          const sessions = await admin.users.listSessions({ id: user.id! })
-          if (sessions && sessions.length > 0) {
-            // Find the most recent session
-            const latestSession = sessions.reduce((latest, session) => 
-              (session.lastAccess || 0) > (latest.lastAccess || 0) ? session : latest
-            )
-            lastLogin = latestSession.lastAccess || null
-          }
-        } catch (sessionError) {
-          logger.admin.warn(`Could not get sessions for user ${user.username}`, { error: sessionError })
-        }
         
         // Get user's realm roles and client roles
         let realmRoles: string[] = []
@@ -126,15 +120,13 @@ export const healthcareUsersRoutes = new Elysia({ prefix: '/healthcare-users' })
           realmRoles = userRoles.map(role => role.name || '').filter(Boolean)
           
           // Get client role mappings for admin-ui client
-          try {
-            const clients = await admin.clients.find({ clientId: 'admin-ui' })
-            if (clients.length > 0) {
-              const clientId = clients[0].id!
-              const userClientRoles = await admin.users.listClientRoleMappings({ id: user.id!, clientUniqueId: clientId })
+          if (adminUiClientId) {
+            try {
+              const userClientRoles = await admin.users.listClientRoleMappings({ id: user.id!, clientUniqueId: adminUiClientId })
               clientRoles['admin-ui'] = userClientRoles.map(role => role.name || '').filter(Boolean)
+            } catch (clientRoleError) {
+              logger.admin.warn(`Could not get client roles for user ${user.username}`, { error: clientRoleError })
             }
-          } catch (clientRoleError) {
-            logger.admin.warn(`Could not get client roles for user ${user.username}`, { error: clientRoleError })
           }
         } catch (roleError) {
           logger.admin.warn(`Could not get roles for user ${user.username}`, { error: roleError })
@@ -161,7 +153,6 @@ export const healthcareUsersRoutes = new Elysia({ prefix: '/healthcare-users' })
           realmRoles,
           clientRoles,
           organization,
-          lastLogin: lastLogin,
           federatedIdentities
         }
       }))

--- a/backend/src/routes/auth/oauth/token.ts
+++ b/backend/src/routes/auth/oauth/token.ts
@@ -18,6 +18,7 @@ import { validateToken } from '@/lib/auth'
 import { getAllServers } from '@/lib/fhir-server-store'
 import { getSmartClientConfig } from '@/lib/smart-client-config-cache'
 import { resolveFhirUserForClient } from '@/lib/consent/person-resolver'
+import { recordLastLogin } from '@/lib/last-login'
 import { tokenContextStore } from '@/lib/token-context-store'
 import { hasClientAssertion, translateClientAssertion, ClientAssertionError } from '../backend-services'
 import { smartProxyConfig, smartStore, keycloakAdapter, smartLogger } from '../smart-proxy-setup'
@@ -92,11 +93,16 @@ function buildKeycloakForm(
  */
 async function applyLaunchContext(
   data: TokenResponseBody,
-  input: { accessToken: string; clientId?: string; redirectUri?: string; requestedScope?: string },
+  input: { accessToken: string; clientId?: string; redirectUri?: string; requestedScope?: string; grantType?: string },
 ): Promise<void> {
-  const { accessToken, clientId, redirectUri, requestedScope } = input
+  const { accessToken, clientId, redirectUri, requestedScope, grantType } = input
 
   const tokenPayload = await validateToken(accessToken)
+
+  // Not awaited: the sign-in is already granted, and stamping it must not delay the response.
+  if (grantType === 'authorization_code' && typeof tokenPayload.sub === 'string') {
+    void recordLastLogin(tokenPayload.sub)
+  }
 
   const enrichment = enrichTokenResponse(
     {
@@ -271,6 +277,7 @@ export const tokenRoutes = new Elysia({ tags: ['authentication'] })
             clientId: clientIdForSession,
             redirectUri: clientRedirectUri,
             requestedScope,
+            grantType: bodyObj.grant_type || bodyObj.grantType,
           })
         } catch (contextError) {
           logger.auth.warn('Failed to add launch context to token response', { contextError })


### PR DESCRIPTION
Two user attributes where one half of the system wrote and the other half could not see it.

## `lastLogin` read `null` for every user

The healthcare-users list derived it from `admin.users.listSessions()`, which only sees sessions that are still alive — so once SSO sessions idle out the field is null for everyone, and it can never answer the question its name asks.

`mapHealthcareUser` already reads the `lastLogin` user attribute that the realm's user profile declares. The route then overwrote that value with the session-derived one. This drops the override and the per-user session lookup with it.

Nothing ever wrote that attribute, so it is now stamped on the `authorization_code` grant — not on refresh, which is not a login. Best-effort and not awaited: a failure must not delay or fail a sign-in Keycloak has already granted.

Login-event storage was deliberately not enabled. It is the more canonical source, but retaining per-user access logs is a retention decision rather than a code change, and the realm already declares an attribute for exactly this.

## The membership attributes never persisted

The maxhealth IdP has attribute importers for `membership_tier`, `early_access` and `premium_support`, all `syncMode: FORCE`, and the upstream sends all three on every login — `membership_tier` unconditionally, defaulting to `free`.

None of the three was declared on the realm's user profile. Keycloak 26 drops undeclared attributes silently, so the writes went nowhere: no user carried a `membership_tier` attribute, the `aihr-portal` protocol mapper that reads it emitted nothing, and every brokered user resolved as the free tier.

`fhirUser` was unaffected only because it is declared, which is what made these look like two unrelated problems.

`ensureUserProfileAttributes` only ever appends what is missing, so this applies on the next boot and removes nothing.

## Follow-up, not included here

`/admin/idps/:alias/mapper-status` reports `healthy: true` throughout the above: it verifies that mappers exist, but not that each mapper's target attribute is declared on the user profile. Adding that check is what would surface this class of problem without a live user read.

## Verification

`typecheck`, `lint` and the suite (1581 pass / 1 skip / 0 fail) green locally on both commits together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)