### PR TITLE
test(e2e): match the sign-in button on SMART, not its full label

### DIFF
--- a/testing/e2e/lib/auth.ts
+++ b/testing/e2e/lib/auth.ts
@@ -1,6 +1,9 @@
 import { type Page, expect } from "@playwright/test"
 import { env, testUsers } from "./env"
 
+/** Matched on the protocol name, so a change to the button's wording does not break the flow. */
+const SIGN_IN_BUTTON = /SMART/i
+
 /**
  * Performs Keycloak login on the current page.
  * Expects the page to be on the Keycloak login form.
@@ -23,7 +26,7 @@ export async function keycloakLogin(
 /**
  * Navigate to patient-portal and perform full SMART login flow:
  * 1. Go to patient portal
- * 2. Click "Sign In with SMART"
+ * 2. Click the SMART login button
  * 3. Handle Keycloak login
  * 4. Wait for callback redirect and authenticated state
  *
@@ -43,7 +46,7 @@ export async function smartLogin(
   }
 
   // Click sign in
-  const signInButton = page.getByRole("button", { name: "Sign In with SMART" })
+  const signInButton = page.getByRole("button", { name: SIGN_IN_BUTTON })
   await expect(signInButton).toBeVisible({ timeout: 10_000 })
   await signInButton.click()
 
@@ -90,7 +93,7 @@ export async function smartLogout(page: Page): Promise<void> {
 
   // Should return to unauthenticated state
   await expect(
-    page.getByRole("button", { name: "Sign In with SMART" }),
+    page.getByRole("button", { name: SIGN_IN_BUTTON }),
   ).toBeVisible({ timeout: 15_000 })
 }
 
@@ -111,7 +114,7 @@ export async function consentLogin(
   }
 
   // Click sign in
-  const signInButton = page.getByRole("button", { name: "Sign In with SMART" })
+  const signInButton = page.getByRole("button", { name: SIGN_IN_BUTTON })
   await expect(signInButton).toBeVisible({ timeout: 10_000 })
   await signInButton.click()
 


### PR DESCRIPTION
The sign-in button in patient-portal and consent-app is being renamed from "Sign In with SMART" to "SMART Login", because the old wording read as a protocol name to the people who had to click it. All three locators in `testing/e2e/lib/auth.ts` matched the full label and would have broken on the next beta deploy of those apps.

The locator now matches `/SMART/i` instead, which holds for either wording and keeps these helpers independent of product copy. One constant, three uses.

Two pre-existing things this touches but does not change, worth a look separately:

- `smartLogin` and `smartLogout` have no callers, and there are no spec files under `testing/e2e` for them to serve.
- `smartLogin` reads `env.patientPortalURL`, which `E2EEnv` does not define; the beta target has no patient-portal URL at all. That is a type error waiting for whoever adds the first spec.